### PR TITLE
Fix typo in docstring in DataStore.get method

### DIFF
--- a/pybotters/store.py
+++ b/pybotters/store.py
@@ -161,7 +161,7 @@ class DataStore:
             item: DataStore のキー (:attr:`.DataStore._KES`) を指定する辞書
 
         Returns:
-            キーに一致するアイテムがアイテムがあればそのアイテムを返します。
+            キーに一致するアイテムがあればそのアイテムを返します。
             なければ None を返します
         """
         if self._keys:


### PR DESCRIPTION
## 変更内容

- [x] DataStore.get メソッドの docstring の typo を修正