### PR TITLE
Fix conditions for dispatching JSON handlers

### DIFF
--- a/pybotters/ws.py
+++ b/pybotters/ws.py
@@ -238,7 +238,7 @@ class WebSocketApp:
             for hdlr in hdlr_bytes:
                 self._loop.call_soon(hdlr, msg.data, ws)
 
-        if hdlr_json:
+        if hdlr_json and msg.type in {aiohttp.WSMsgType.TEXT, aiohttp.WSMsgType.BINARY}:
             try:
                 data = msg.json()
             except json.JSONDecodeError as e:


### PR DESCRIPTION
Fix a bug caused by #281.

```py
Traceback (most recent call last):
  File "/home/kntm2/repositories/pybotters/pybotters/ws.py", line 243, in _onmessage
    data = msg.json()
  File "/home/kntm2/repositories/pybotters/.hatch/pybotters/lib/python3.8/site-packages/aiohttp/http_websocket.py", line 121, in json
    return loads(self.data)
  File "/home/kntm2/.local/lib/python3.8/json/__init__.py", line 357, in loads
    return _default_decoder.decode(s)
  File "/home/kntm2/.local/lib/python3.8/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/home/kntm2/.local/lib/python3.8/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/kntm2/.local/lib/python3.8/asyncio/events.py", line 81, in _run
    self._context.run(self._callback, *self._args)
  File "/home/kntm2/repositories/pybotters/pybotters/ws.py", line 245, in _onmessage
    if msg.data not in {"ping", "pong"}:
TypeError: unhashable type: 'bytearray'
ERROR    asyncio:base_events.py:1707 Exception in callback WebSocketApp._onmessage(WSMessage(typ...5'), extra=''), <pybotters.ws...x7a25d5392cd0>, [], [], [<bound method... _getters[1]>>])
handle: <Handle WebSocketApp._onmessage(WSMessage(typ...5'), extra=''), <pybotters.ws...x7a25d5392cd0>, [], [], [<bound method... _getters[1]>>])>
Traceback (most recent call last):
  File "/home/kntm2/.local/lib/python3.8/asyncio/events.py", line 81, in _run
    self._context.run(self._callback, *self._args)
  File "/home/kntm2/repositories/pybotters/pybotters/ws.py", line 243, in _onmessage
    data = msg.json()
  File "/home/kntm2/repositories/pybotters/.hatch/pybotters/lib/python3.8/site-packages/aiohttp/http_websocket.py", line 121, in json
    return loads(self.data)
  File "/home/kntm2/.local/lib/python3.8/json/__init__.py", line 343, in loads
    s = s.decode(detect_encoding(s), 'surrogatepass')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xed in position 1: invalid continuation byte
```

Changed pybotters side to receive Ping/Pong frames, but did not fix the condition for dispatching JSON handlers.

However, the only user impact is log output. The WebSocketApp handler is scheduled by `call_soon()` in the event loop, so this exception is not propagated to WebSocketApp.