### PR TITLE
Update Bybit WebSocket heartbeat interval to 20 seconds

### DIFF
--- a/pybotters/ws.py
+++ b/pybotters/ws.py
@@ -325,7 +325,7 @@ class Heartbeat:
     async def bybit(ws: aiohttp.ClientWebSocketResponse):
         while not ws.closed:
             await ws.send_str('{"op":"ping"}')
-            await asyncio.sleep(30.0)
+            await asyncio.sleep(20.0)
 
     @staticmethod
     async def bitbank(ws: aiohttp.ClientWebSocketResponse):


### PR DESCRIPTION
Bybitのおすすめ( https://bybit-exchange.github.io/docs/v5/ws/connect )に基づいて、
Heartbeatのインターバルが30秒だったのを20秒に変更しました。

プルリクエスト初めてなので不足している点などあればすみません。何かあればご指摘いただけると幸いです。