### PR TITLE
Support Bybit Demo Trading Service

### DIFF
--- a/docs/exchanges.rst
+++ b/docs/exchanges.rst
@@ -164,6 +164,7 @@ Authentication
 
 * API 認証情報
     * ``{"bybit": ["API_KEY", "API_SERCRET"]}``
+    * ``{"bybit_demo": ["API_KEY", "API_SERCRET"]}``
     * ``{"bybit_testnet": ["API_KEY", "API_SERCRET"]}``
 * HTTP 認証
     HTTP リクエスト時に取引所が定める認証情報が自動設定されます。

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -361,6 +361,7 @@ Bitget                    ``bitget``
 BitMEX                    ``bitmex``
 BitMEX Testnet            ``bitmex_testnet``
 Bybit                     ``bybit``
+Bybit Demo trading        ``bybit_demo``
 Bybit Testnet             ``bybit_testnet``
 Coincheck                 ``coincheck``
 GMO Coin                  ``gmocoin``

--- a/pybotters/auth.py
+++ b/pybotters/auth.py
@@ -421,6 +421,7 @@ class Hosts:
     items = {
         "api.bybit.com": Item("bybit", Auth.bybit),
         "api.bytick.com": Item("bybit", Auth.bybit),
+        "api-demo.bybit.com": Item("bybit_demo", Auth.bybit),
         "api-testnet.bybit.com": Item("bybit_testnet", Auth.bybit),
         "api.binance.com": Item("binance", Auth.binance),
         "api-gcp.binance.com": Item("binance", Auth.binance),

--- a/pybotters/ws.py
+++ b/pybotters/ws.py
@@ -579,6 +579,7 @@ class HeartbeatHosts:
         "stream.bitbank.cc": Heartbeat.bitbank,
         "stream.bybit.com": Heartbeat.bybit,
         "stream.bytick.com": Heartbeat.bybit,
+        "stream-demo.bybit.com": Heartbeat.bybit,
         "stream-testnet.bybit.com": Heartbeat.bybit,
         "stream.binance.com": Heartbeat.binance,
         "fstream.binance.com": Heartbeat.binance,
@@ -607,6 +608,7 @@ class AuthHosts:
     items = {
         "stream.bybit.com": Item("bybit", Auth.bybit),
         "stream.bytick.com": Item("bybit", Auth.bybit),
+        "stream-demo.bybit.com": Item("bybit_demo", Auth.bybit),
         "stream-testnet.bybit.com": Item("bybit_testnet", Auth.bybit),
         "ws.lightstream.bitflyer.com": Item("bitflyer", Auth.bitflyer),
         "phemex.com": Item("phemex", Auth.phemex),
@@ -752,5 +754,6 @@ class MessageSignHosts:
         "ws-api.binance.com": Item("binance", MessageSign.binance),
         "testnet.binance.vision": Item("binancespot_testnet", MessageSign.binance),
         "stream.bybit.com": Item("bybit", MessageSign.bybit),
+        "stream-demo.bybit.com": Item("bybit_demo", MessageSign.bybit),
         "stream-testnet.bybit.com": Item("bybit_testnet", MessageSign.bybit),
     }

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -41,6 +41,10 @@ def mock_session(mocker: pytest_mock.MockerFixture):
             "vDGsldGGevgVkG3ATH1PzBYd",
             b"fVp9Y9iZbkCb4JXyprq2ZbbDXupWz5V3H06REf2eJ53DyQju",
         ),
+        "bybit_demo": (
+            "ZpfuTHcfmsWX1kLWpSIUdtsu",
+            b"7wq6s78RI6xHfPRIIt4Dvii2hO7BtFcavs5S2VlKrnGTOnMf",
+        ),
         "binance": (
             "9qm1u2s4GoHt9ryIm1D2fHV8",
             b"7pDOQJ49zyyDjrNGAvB31RcnAada8nkxkl2IWKop6b0E3tXh",


### PR DESCRIPTION
Bybitのデモ取引用APIのドメインを追加しました。
公式の案内は下記URLです。
https://bybit-exchange.github.io/docs/v5/demo

コメントなども変更加えられると良かったのですが、そちらには反映できていません。
数日動かしてみてエラーがでないことを確認しています。