### PR TITLE
Fix minor typo in the docstring of DataStore.get

### DIFF
--- a/pybotters/store.py
+++ b/pybotters/store.py
@@ -158,7 +158,7 @@ class DataStore:
         """DataStore から Item を取得します。
 
         Args:
-            item: DataStore のキー (:attr:`.DataStore._KES`) を指定する辞書
+            item: DataStore のキー (:attr:`.DataStore._KEYS`) を指定する辞書
 
         Returns:
             キーに一致するアイテムがあればそのアイテムを返します。


### PR DESCRIPTION
DataStore.get() の docstring について _KEYS が _KES となっている typo を修正しています。

リポジトリ全体を _KES で検索し、他に同様の箇所が無い事を確認済みです。
