### PR TITLE
Update API documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ It has the following features, making it useful for developing a trading bot.
 | Binance | ✅ | ✅ | [Link](https://developers.binance.com/docs/binance-spot-api-docs/CHANGELOG) |
 | OKX | ✅ | ✅ | [Link](https://www.okx.com/docs-v5/en/) |
 | Phemex | ✅ | ✅ | [Link](https://phemex-docs.github.io/) |
-| Bitget | ✅ | ✅ | [Link](https://www.bitget.com/api-doc/common/intro) |
+| Bitget | ✅ | ✅ | [Link](https://bitgetlimited.github.io/apidoc/en/mix/) |
 | MEXC | ✅ | No support | [Link](https://mexcdevelop.github.io/apidocs/spot_v3_en/) |
 | KuCoin | ✅ | ✅ | [Link](https://www.kucoin.com/docs/beginners/introduction) |
 | BitMEX | ✅ | ✅ | [Link](https://www.bitmex.com/app/apiOverview) |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 
 [![CI](https://github.com/pybotters/pybotters/actions/workflows/ci.yml/badge.svg)](https://github.com/pybotters/pybotters/actions/workflows/ci.yml)
 [![publish](https://github.com/pybotters/pybotters/actions/workflows/publish.yml/badge.svg)](https://github.com/pybotters/pybotters/actions/workflows/publish.yml)
-[![codecov](https://codecov.io/gh/pybotters/pybotters/graph/badge.svg?token=ARR29R726W)](https://codecov.io/gh/pybotters/pybotters)
 [![Documentation Status](https://readthedocs.org/projects/pybotters/badge/?version=latest)](https://pybotters.readthedocs.io/ja/latest/?badge=latest)
 [![Hatch project](https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg)](https://github.com/pypa/hatch)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
@@ -55,10 +54,10 @@ It has the following features, making it useful for developing a trading bot.
 | bitbank | ✅ | ✅ | [Link](https://github.com/bitbankinc/bitbank-api-docs) |
 | Coincheck | ✅ | ✅ | [Link](https://coincheck.com/ja/documents/exchange/api) |
 | Bybit | ✅ | ✅ | [Link](https://bybit-exchange.github.io/docs/v5/intro) |
-| Binance | ✅ | ✅ | [Link](https://binance-docs.github.io/apidocs/spot/en/) |
+| Binance | ✅ | ✅ | [Link](https://developers.binance.com/docs/binance-spot-api-docs/CHANGELOG) |
 | OKX | ✅ | ✅ | [Link](https://www.okx.com/docs-v5/en/) |
 | Phemex | ✅ | ✅ | [Link](https://phemex-docs.github.io/) |
-| Bitget | ✅ | ✅ | [Link](https://bitgetlimited.github.io/apidoc/en/mix/) |
+| Bitget | ✅ | ✅ | [Link](https://www.bitget.com/api-doc/common/intro) |
 | MEXC | ✅ | No support | [Link](https://mexcdevelop.github.io/apidocs/spot_v3_en/) |
 | KuCoin | ✅ | ✅ | [Link](https://www.kucoin.com/docs/beginners/introduction) |
 | BitMEX | ✅ | ✅ | [Link](https://www.bitmex.com/app/apiOverview) |

--- a/docs/exchanges.rst
+++ b/docs/exchanges.rst
@@ -198,7 +198,7 @@ DataStore
 Binance
 -------
 
-https://binance-docs.github.io/apidocs/spot/en/
+https://developers.binance.com/docs/binance-spot-api-docs/CHANGELOG
 
 pybotters は Binance API において Spot /USDⓈ-M / COIN-M / WebSocket API (Spot) で動作確認をしています。
 
@@ -212,15 +212,15 @@ Authentication
 * HTTP 認証
     HTTP リクエスト時に取引所が定める認証情報が自動設定されます。
 
-    * https://binance-docs.github.io/apidocs/spot/en/#signed-trade-user_data-and-margin-endpoint-security
-    * https://binance-docs.github.io/apidocs/futures/en/#signed-trade-and-user_data-endpoint-security
-    * https://binance-docs.github.io/apidocs/delivery/en/#signed-trade-and-user_data-endpoint-security
+    * https://developers.binance.com/docs/binance-spot-api-docs/rest-api#signed-endpoint-examples-for-post-apiv3order
+    * https://developers.binance.com/docs/derivatives/usds-margined-futures/general-info#signed-trade-and-user_data-endpoint-security
+    * https://developers.binance.com/docs/derivatives/coin-margined-futures/general-info#signed-trade-and-user_data-endpoint-security
 * WebSocket 認証
     Binance はトークン認証方式の為、ユーザーコードで URL に ``listenKey`` 含める必要があります。
 
-    * https://binance-docs.github.io/apidocs/spot/en/#user-data-streams
-    * https://binance-docs.github.io/apidocs/futures/en/#user-data-streams
-    * https://binance-docs.github.io/apidocs/delivery/en/#user-data-streams
+    * https://developers.binance.com/docs/binance-spot-api-docs/user-data-stream
+    * https://developers.binance.com/docs/derivatives/usds-margined-futures/user-data-streams/Connect
+    * https://developers.binance.com/docs/derivatives/coin-margined-futures/user-data-streams/Connect
 
     ただし Binance 系 DataStore に ``listenKey`` を管理する機能があります。
 
@@ -233,11 +233,11 @@ Authentication
     pybotters では Binance で *WebSocket API* と表されるタイプの API 認証に対応しています。
     これは WebSocket メッセージで注文の作成などを可能にするもので、現時点では Spot のみ対応しています。
 
-    https://binance-docs.github.io/apidocs/websocket_api/en/
+    https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api
 
     送信する WebSocket メッセージに対して、取引所が定める認証情報が自動設定されます。
 
-    https://binance-docs.github.io/apidocs/websocket_api/en/#signed-trade-and-user_data-request-security
+    https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api#signed-trade-and-user_data-request-security
 
     これを利用するには、 :attr:`.WebSocketApp.current_ws` から ``send_json()`` メソッドを利用して引数 ``auth=pybotters.Auth`` を設定します。
 
@@ -247,7 +247,7 @@ WebSocket
 * レート制限
     pybotters は Binance Spot のみにある WebSocket API の購読レート制限に対応しています。
 
-    https://binance-docs.github.io/apidocs/spot/en/#limits
+    https://developers.binance.com/docs/binance-spot-api-docs/web-socket-streams#websocket-limits
 
     :meth:`.Client.ws_connect` でメッセージを送信する際、レート制限が自動適用されます。
 

--- a/pybotters/models/binance.py
+++ b/pybotters/models/binance.py
@@ -189,12 +189,12 @@ class BinanceDataStoreBase(DataStoreCollection):
         """trade/aggTrade stream.
 
         * Spot
-            * https://binance-docs.github.io/apidocs/spot/en/#aggregate-trade-streams
-            * https://binance-docs.github.io/apidocs/spot/en/#trade-streams
+            * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-streams#aggregate-trade-streams
+            * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-streams#trade-streams
         * USDⓈ-M
-            * https://binance-docs.github.io/apidocs/futures/en/#aggregate-trade-streams
+            * https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Aggregate-Trade-Streams
         * COIN-M
-            * https://binance-docs.github.io/apidocs/delivery/en/#aggregate-trade-streams
+            * https://developers.binance.com/docs/derivatives/coin-margined-futures/websocket-market-streams/Aggregate-Trade-Streams
         """
         return self._get("trade", Trade)
 
@@ -203,11 +203,11 @@ class BinanceDataStoreBase(DataStoreCollection):
         """kline stream.
 
         * Spot
-            * https://binance-docs.github.io/apidocs/spot/en/#kline-candlestick-streams
+            * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-streams#klinecandlestick-streams-for-utc
         * USDⓈ-M
-            * https://binance-docs.github.io/apidocs/futures/en/#kline-candlestick-streams
+            * https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Kline-Candlestick-Streams
         * COIN-M
-            * https://binance-docs.github.io/apidocs/delivery/en/#kline-candlestick-streams
+            * https://developers.binance.com/docs/derivatives/coin-margined-futures/websocket-market-streams/Kline-Candlestick-Streams
         """
         return self._get("kline", Kline)
 
@@ -216,14 +216,14 @@ class BinanceDataStoreBase(DataStoreCollection):
         """24hrMiniTicker/24hrTicker stream.
 
         * Spot
-            * https://binance-docs.github.io/apidocs/spot/en/#individual-symbol-mini-ticker-stream
-            * https://binance-docs.github.io/apidocs/spot/en/#individual-symbol-ticker-streams
+            * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-streams#individual-symbol-mini-ticker-stream
+            * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-streams#individual-symbol-ticker-streams
         * USDⓈ-M
-            * https://binance-docs.github.io/apidocs/futures/en/#individual-symbol-mini-ticker-stream
-            * https://binance-docs.github.io/apidocs/futures/en/#individual-symbol-ticker-streams
+            * https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Individual-Symbol-Mini-Ticker-Stream
+            * https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Individual-Symbol-Ticker-Streams
         * COIN-M
-            * https://binance-docs.github.io/apidocs/delivery/en/#individual-symbol-mini-ticker-stream
-            * https://binance-docs.github.io/apidocs/delivery/en/#individual-symbol-ticker-streams
+            * https://developers.binance.com/docs/derivatives/coin-margined-futures/websocket-market-streams/Individual-Symbol-Mini-Ticker-Stream
+            * https://developers.binance.com/docs/derivatives/coin-margined-futures/websocket-market-streams/Individual-Symbol-Ticker-Streams
         """
         return self._get("ticker", Ticker)
 
@@ -232,11 +232,11 @@ class BinanceDataStoreBase(DataStoreCollection):
         """bookTicker stream.
 
         * Spot
-            * https://binance-docs.github.io/apidocs/spot/en/#individual-symbol-book-ticker-streams
+            * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-streams#individual-symbol-book-ticker-streams
         * USDⓈ-M
-            * https://binance-docs.github.io/apidocs/futures/en/#individual-symbol-book-ticker-streams
+            * https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Individual-Symbol-Book-Ticker-Streams
         * COIN-M
-            * https://binance-docs.github.io/apidocs/delivery/en/#individual-symbol-book-ticker-streams
+            * https://developers.binance.com/docs/derivatives/coin-margined-futures/websocket-market-streams/Individual-Symbol-Book-Ticker-Streams
         """
         return self._get("bookticker", BookTicker)
 
@@ -245,11 +245,11 @@ class BinanceDataStoreBase(DataStoreCollection):
         """depthUpdate stream.
 
         * Spot
-            * https://binance-docs.github.io/apidocs/spot/en/#diff-depth-stream
+            * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-streams#diff-depth-stream
         * USDⓈ-M
-            * https://binance-docs.github.io/apidocs/futures/en/#diff-book-depth-streams
+            * https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Diff-Book-Depth-Streams
         * COIN-M
-            * https://binance-docs.github.io/apidocs/delivery/en/#diff-book-depth-streams
+            * https://developers.binance.com/docs/derivatives/coin-margined-futures/websocket-market-streams/Diff-Book-Depth-Streams
         """
         return self._get("orderbook", OrderBook)
 
@@ -260,11 +260,11 @@ class BinanceDataStoreBase(DataStoreCollection):
         アクティブオーダーのみデータが格納されます。 キャンセル、約定済みなどは削除されます。
 
         * Spot
-            * https://binance-docs.github.io/apidocs/spot/en/#payload-order-update
+            * https://developers.binance.com/docs/binance-spot-api-docs/user-data-stream#order-update
         * USDⓈ-M
-            * https://binance-docs.github.io/apidocs/futures/en/#event-order-update
+            * https://developers.binance.com/docs/derivatives/usds-margined-futures/user-data-streams/Event-Order-Update
         * COIN-M
-            * https://binance-docs.github.io/apidocs/delivery/en/#event-order-update
+            * https://developers.binance.com/docs/derivatives/coin-margined-futures/user-data-streams/Event-Order-Update
         """
         return self._get("order", Order)
 
@@ -328,8 +328,8 @@ class BinanceFuturesDataStoreBase(BinanceDataStoreBase):
     def markprice(self) -> "MarkPrice":
         """markPriceUpdate stream.
 
-        * https://binance-docs.github.io/apidocs/futures/en/#mark-price-stream
-        * https://binance-docs.github.io/apidocs/delivery/en/#mark-price-stream
+        * https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Mark-Price-Stream
+        * https://developers.binance.com/docs/derivatives/coin-margined-futures/websocket-market-streams/Mark-Price-Stream
         """
         return self._get("markprice", MarkPrice)
 
@@ -337,8 +337,8 @@ class BinanceFuturesDataStoreBase(BinanceDataStoreBase):
     def continuouskline(self) -> "ContinuousKline":
         """continuous_kline stream.
 
-        * https://binance-docs.github.io/apidocs/futures/en/#continuous-contract-kline-candlestick-data
-        * https://binance-docs.github.io/apidocs/delivery/en/#continuous-contract-kline-candlestick-data
+        * https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Continuous-Contract-Kline-Candlestick-Streams
+        * https://developers.binance.com/docs/derivatives/coin-margined-futures/websocket-market-streams/Continuous-Contract-Kline-Candlestick-Streams
         """
         return self._get("continuouskline", ContinuousKline)
 
@@ -346,8 +346,8 @@ class BinanceFuturesDataStoreBase(BinanceDataStoreBase):
     def liquidation(self) -> "Liquidation":
         """forceOrder stream.
 
-        * https://binance-docs.github.io/apidocs/futures/en/#liquidation-order-streams
-        * https://binance-docs.github.io/apidocs/delivery/en/#all-market-liquidation-order-streams
+        * https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Liquidation-Order-Streams
+        * https://developers.binance.com/docs/derivatives/coin-margined-futures/websocket-market-streams/Liquidation-Order-Streams
         """
         return self._get("liquidation", Liquidation)
 
@@ -355,8 +355,8 @@ class BinanceFuturesDataStoreBase(BinanceDataStoreBase):
     def balance(self) -> "Balance":
         """ACCOUNT_UPDATE from User Data Streams.
 
-        * https://binance-docs.github.io/apidocs/futures/en/#event-balance-and-position-update
-        * https://binance-docs.github.io/apidocs/delivery/en/#event-balance-and-position-update
+        * https://developers.binance.com/docs/derivatives/usds-margined-futures/user-data-streams/Event-Balance-and-Position-Update
+        * https://developers.binance.com/docs/derivatives/coin-margined-futures/user-data-streams/Event-Balance-and-Position-Update
         """
         return self._get("balance", Balance)
 
@@ -364,8 +364,8 @@ class BinanceFuturesDataStoreBase(BinanceDataStoreBase):
     def position(self) -> "Position":
         """ACCOUNT_UPDATE from User Data Streams.
 
-        * https://binance-docs.github.io/apidocs/futures/en/#event-balance-and-position-update
-        * https://binance-docs.github.io/apidocs/delivery/en/#event-balance-and-position-update
+        * https://developers.binance.com/docs/derivatives/usds-margined-futures/user-data-streams/Event-Balance-and-Position-Update
+        * https://developers.binance.com/docs/derivatives/coin-margined-futures/user-data-streams/Event-Balance-and-Position-Update
         """
         return self._get("position", Position)
 
@@ -412,7 +412,7 @@ class BinanceSpotDataStore(BinanceDataStoreBase):
     def account(self):
         """outboundAccountPosition from User Data Streams.
 
-        https://binance-docs.github.io/apidocs/spot/en/#payload-account-update
+        https://developers.binance.com/docs/binance-spot-api-docs/user-data-stream#account-update
         """
         return self._get("account", Account)
 
@@ -420,7 +420,7 @@ class BinanceSpotDataStore(BinanceDataStoreBase):
     def ocoorder(self):
         """listStatus from User Data Streams.
 
-        https://binance-docs.github.io/apidocs/spot/en/#payload-order-update
+        https://developers.binance.com/docs/binance-spot-api-docs/user-data-stream#conditional-fields-in-execution-report
         """
         return self._get("ocoorder", OCOOrder)
 
@@ -457,7 +457,7 @@ class BinanceUSDSMDataStore(BinanceFuturesDataStoreBase):
     def compositeindex(self) -> "CompositeIndex":
         """compositeindex stream.
 
-        https://binance-docs.github.io/apidocs/futures/en/#composite-index-symbol-information-streams
+        https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Composite-Index-Symbol-Information-Streams
         """
         return self._get("compositeindex", CompositeIndex)
 
@@ -521,7 +521,7 @@ class BinanceCOINMDataStore(BinanceFuturesDataStoreBase):
     def indexprice(self) -> "IndexPrice":
         """indexprice stream.
 
-        https://binance-docs.github.io/apidocs/delivery/en/#index-price-stream
+        https://developers.binance.com/docs/derivatives/coin-margined-futures/websocket-market-streams/Index-Price-Stream
         """
         return self._get("indexprice", IndexPrice)
 
@@ -529,7 +529,7 @@ class BinanceCOINMDataStore(BinanceFuturesDataStoreBase):
     def indexpricekline(self) -> "Kline":
         """indexpricekline stream.
 
-        https://binance-docs.github.io/apidocs/delivery/en/#index-kline-candlestick-streams
+        https://developers.binance.com/docs/derivatives/coin-margined-futures/websocket-market-streams/Index-Kline-Candlestick-Streams
         """
         return self._get("indexpricekline", Kline)
 
@@ -537,7 +537,7 @@ class BinanceCOINMDataStore(BinanceFuturesDataStoreBase):
     def markpricekline(self) -> "Kline":
         """markpricekline stream.
 
-        https://binance-docs.github.io/apidocs/delivery/en/#mark-price-kline-candlestick-streams
+        https://developers.binance.com/docs/derivatives/coin-margined-futures/websocket-market-streams/Mark-Price-Kline-Candlestick-Streams
         """
         return self._get("markpricekline", Kline)
 


### PR DESCRIPTION
This pull request updates the links for the Binance ~and Bitget~ APIs to their latest documentation. The previous links were outdated and have been replaced with the correct ones. This ensures that users have access to the most up-to-date information when using these APIs.

In addition, codecov batches not currently in use will be removed.