### PR TITLE
Ensure missing passphrase

### DIFF
--- a/pybotters/auth.py
+++ b/pybotters/auth.py
@@ -451,3 +451,7 @@ class Hosts:
         "api.kucoin.com": Item("kucoin", Auth.kucoin),
         "api-futures.kucoin.com": Item("kucoin", Auth.kucoin),
     }
+
+
+class PassphraseRequiredExchanges:
+    items = {"bitget", "kucoin"}

--- a/pybotters/client.py
+++ b/pybotters/client.py
@@ -12,7 +12,7 @@ from aiohttp import hdrs
 from aiohttp.client import _RequestContextManager
 
 from .__version__ import __version__
-from .auth import Auth
+from .auth import Auth, PassphraseRequiredExchanges
 from .request import ClientRequest
 from .typedefs import WsBytesHandler, WsJsonHandler, WsStrHandler
 from .ws import ClientWebSocketResponse, WebSocketApp
@@ -314,6 +314,9 @@ class Client:
     def _encode_apis(apis: dict[str, list[str]]) -> dict[str, tuple[str | bytes, ...]]:
         encoded = {}
         for name in apis:
+            if name in PassphraseRequiredExchanges.items and len(apis[name]) < 3:
+                logger.warning(f"Missing passphrase for {name}")
+                continue
             if len(apis[name]) >= 2:
                 apis[name][1] = apis[name][1].encode()
             encoded[name] = tuple(apis[name])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -48,7 +48,7 @@ async def test_client_warn(mocker: pytest_mock.MockerFixture):
 
 
 @pytest.mark.asyncio
-async def test_client_with_missing_passphrase_apis():
+async def test_client_with_missing_passphrase_apis(caplog: pytest.LogCaptureFixture):
     passphrase_required_exchanges = sorted(
         pybotters.auth.PassphraseRequiredExchanges.items
     )
@@ -57,6 +57,9 @@ async def test_client_with_missing_passphrase_apis():
         assert isinstance(client._session, aiohttp.ClientSession)
         assert not client._session.closed
     assert client._session.__dict__["_apis"] == {}
+    assert [rec.message for rec in caplog.records] == [
+        f"Missing passphrase for {x}" for x in passphrase_required_exchanges
+    ]
 
 
 def test_client_load_apis_current(mocker: pytest_mock.MockerFixture):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -47,6 +47,18 @@ async def test_client_warn(mocker: pytest_mock.MockerFixture):
     assert client._session.__dict__["_apis"] == {}
 
 
+@pytest.mark.asyncio
+async def test_client_with_missing_passphrase_apis():
+    passphrase_required_exchanges = sorted(
+        pybotters.auth.PassphraseRequiredExchanges.items
+    )
+    apis = {x: ["key", "secret"] for x in passphrase_required_exchanges}
+    async with pybotters.Client(apis=apis) as client:
+        assert isinstance(client._session, aiohttp.ClientSession)
+        assert not client._session.closed
+    assert client._session.__dict__["_apis"] == {}
+
+
 def test_client_load_apis_current(mocker: pytest_mock.MockerFixture):
     mocker.patch("os.path.isfile", return_value=True)
     mocker.patch("builtins.open", mock_open(read_data='{"foo":"bar"}'))


### PR DESCRIPTION
If API credentials require a passphrase but you do not have one, skip encoding the credentials with `apis`. In that case, a further warning log is output.

Previously, without this check, a KeyError was raised in `auth.py` if the credentials did not have a passphrase.