### PR TITLE
Support bitbank ACCESS-TIME-WINDOW authentication method

### DIFF
--- a/docs/exchanges.rst
+++ b/docs/exchanges.rst
@@ -97,7 +97,7 @@ Authentication
 * API 認証情報
     * ``{"bitbank": ["API_KEY", "API_SERCRET"]}``
 * HTTP 認証
-    HTTP リクエスト時に取引所が定める認証情報が自動設定されます。
+    HTTP リクエスト時に取引所が定める認証情報が自動設定されます。 認証方式は ``ACCESS-TIME-WINDOW`` を採用します。
 
     https://github.com/bitbankinc/bitbank-api-docs/blob/master/rest-api_JP.md#%E8%AA%8D%E8%A8%BC
 * WebSocket 認証

--- a/pybotters/auth.py
+++ b/pybotters/auth.py
@@ -150,14 +150,19 @@ class Auth:
         path = url.raw_path_qs
         body = JsonPayload(data) if data else FormData(data)()
         nonce = str(int(time.time() * 1000))
+        window = headers.get("ACCESS-TIME-WINDOW", "")
         if method == METH_GET:
-            text = f"{nonce}{path}".encode()
+            text = f"{nonce}{window}{path}".encode()
         else:
-            text = nonce.encode() + body._value
+            text = f"{nonce}{window}".encode() + body._value
         signature = hmac.new(secret, text, hashlib.sha256).hexdigest()
         kwargs.update({"data": body})
         headers.update(
-            {"ACCESS-KEY": key, "ACCESS-NONCE": nonce, "ACCESS-SIGNATURE": signature}
+            {
+                "ACCESS-KEY": key,
+                "ACCESS-REQUEST-TIME": nonce,
+                "ACCESS-SIGNATURE": signature,
+            }
         )
 
         return args

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -542,9 +542,48 @@ def test_bitbank_get(mock_session, mocker: pytest_mock.MockerFixture):
         "headers": CIMultiDict(
             {
                 "ACCESS-KEY": "l5HGaEzIC3KiMqbYwtAl1r48",
-                "ACCESS-NONCE": "2085848896000",
+                "ACCESS-REQUEST-TIME": "2085848896000",
                 "ACCESS-SIGNATURE": (
                     "87c0358b092b78c4ac8f46bbd447665acbe9c8a136068473d14f8143ac9ac6aa"
+                ),
+            }
+        ),
+        "session": mock_session,
+    }
+    args = pybotters.auth.Auth.bitbank(args, kwargs)
+    assert args == expected_args
+    assert kwargs["data"]._value == expected_kwargs["data"]._value
+    assert kwargs["headers"] == expected_kwargs["headers"]
+
+
+def test_bitbank_get_with_window(mock_session, mocker: pytest_mock.MockerFixture):
+    mocker.patch("time.time", return_value=2085848896.0)
+    args = (
+        "GET",
+        URL("https://api.bitbank.cc/v1/user/spot/order").with_query(
+            {
+                "pair": "btc_jpy",
+            }
+        ),
+    )
+    kwargs = {
+        "data": None,
+        "headers": CIMultiDict({"ACCESS-TIME-WINDOW": "1000"}),
+        "session": mock_session,
+    }
+    expected_args = (
+        "GET",
+        URL("https://api.bitbank.cc/v1/user/spot/order?pair=btc_jpy"),
+    )
+    expected_kwargs = {
+        "data": aiohttp.formdata.FormData({})(),
+        "headers": CIMultiDict(
+            {
+                "ACCESS-TIME-WINDOW": "1000",
+                "ACCESS-KEY": "l5HGaEzIC3KiMqbYwtAl1r48",
+                "ACCESS-REQUEST-TIME": "2085848896000",
+                "ACCESS-SIGNATURE": (
+                    "b01d3c62a7a80fcd6ca46736c9b956c703a7ebedc04d788b9b33b433979e84bd"
                 ),
             }
         ),
@@ -585,7 +624,7 @@ def test_bitbank_post(mock_session, mocker: pytest_mock.MockerFixture):
         "headers": CIMultiDict(
             {
                 "ACCESS-KEY": "l5HGaEzIC3KiMqbYwtAl1r48",
-                "ACCESS-NONCE": "2085848896000",
+                "ACCESS-REQUEST-TIME": "2085848896000",
                 "ACCESS-SIGNATURE": (
                     "d3f190a3707dae355edf4cc38252c02d6aa360d8c3b84f2a734f1ac306b88812"
                 ),


### PR DESCRIPTION
Refer: https://bitbank.cc/blog/articles/406396361

This pull request adds support for the `ACCESS-TIME-WINDOW` authentication method in the bitbank API. It includes changes to the `bitbank` function to handle the `ACCESS-TIME-WINDOW` header in both GET and POST requests. The `bitbank_get_with_window` test case 
has been added to ensure the correct behavior of the new functionality.