### PR TITLE
Fix runtime type annotations

### DIFF
--- a/pybotters/models/bitbank.py
+++ b/pybotters/models/bitbank.py
@@ -96,7 +96,7 @@ class Depth(DataStore):
             self.timestamp = cast(int, data["t"])
 
         for side_item, side in tuples:
-            for item in cast(list[list[str]], data[side_item]):
+            for item in cast("list[list[str]]", data[side_item]):
                 if item[1] != "0":
                     self._update(
                         [

--- a/pybotters/models/coincheck.py
+++ b/pybotters/models/coincheck.py
@@ -107,9 +107,9 @@ class Orderbook(DataStore):
                 )
 
     def _onmessage(self, pair: str, data: dict[str, list[list[str]] | str]) -> None:
-        self.last_update_at = cast(dict[str, str], data).pop("last_update_at")
-        for side in cast(list[list[str]], data):
-            for rate, amount in cast(list[list[str]], data):
+        self.last_update_at = cast("dict[str, str]", data).pop("last_update_at")
+        for side in cast("dict[str, list[list[str]]]", data):
+            for rate, amount in cast("list[list[str]]", data[side]):
                 if amount == "0":
                     self._delete([{"pair": pair, "side": side, "rate": rate}])
                 else:


### PR DESCRIPTION
#303 change broke bitbankDataStore and CoincheckDataStore. This was due to specifying a type argument for a built-in data type in the runtime cast() argument.