### PR TITLE
Support OKJ (OKCoinJapan) Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ It has the following features, making it useful for developing a trading bot.
 | GMO Coin | ✅ | ✅ | [Link](https://api.coin.z.com/docs/) |
 | bitbank | ✅ | ✅ | [Link](https://github.com/bitbankinc/bitbank-api-docs) |
 | Coincheck | ✅ | ✅ | [Link](https://coincheck.com/ja/documents/exchange/api) |
+| OKJ | ✅ | Not yet | [Link](https://dev.okcoin.jp/en/) |
 | Bybit | ✅ | ✅ | [Link](https://bybit-exchange.github.io/docs/v5/intro) |
 | Binance | ✅ | ✅ | [Link](https://developers.binance.com/docs/binance-spot-api-docs/CHANGELOG) |
 | OKX | ✅ | ✅ | [Link](https://www.okx.com/docs-v5/en/) |

--- a/docs/exchanges.rst
+++ b/docs/exchanges.rst
@@ -152,6 +152,31 @@ DataStore
 対応している WebSocket チャンネルはリファレンスの *ATTRIBUTES* をご覧ください。
 
 
+OKJ
+---
+
+https://dev.okcoin.jp/en/
+
+Authentication
+~~~~~~~~~~~~~~
+
+* API 認証情報
+    * ``{"okj": ["API_KEY", "API_SERCRET", "API_PASSPHRASE"]}``
+* HTTP 認証
+    HTTP リクエスト時に取引所が定める認証情報が自動設定されます。
+
+    https://dev.okcoin.jp/en/#summary-yan-zheng
+* WebSocket 認証
+    WebSocket 接続時に取引所が定める認証情報の WebSocket メッセージが自動送信されます。
+
+    https://dev.okcoin.jp/en/#spot_ws-login
+
+DataStore
+~~~~~~~~~
+
+未サポート。
+
+
 Bybit
 -----
 

--- a/docs/exchanges.rst
+++ b/docs/exchanges.rst
@@ -171,6 +171,14 @@ Authentication
 
     https://dev.okcoin.jp/en/#spot_ws-login
 
+WebSocket
+~~~~~~~~~
+
+* Ping-Pong
+    取引所が定める Ping-Pong メッセージが自動送信されます。
+
+    https://dev.okcoin.jp/en/#spot_ws-limit
+
 DataStore
 ~~~~~~~~~
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -371,6 +371,7 @@ OKX                       ``okx``
 OKX Demo trading          ``okx_demo``
 Phemex                    ``phemex``
 Phemex Testnet            ``phemex_testnet``
+OKJ                       ``okj``
 ========================= =========================
 
 また ``apis`` 引数に辞書オブジェクトではなく代わりに **JSON ファイルパス** を文字列として渡すことで、pybotters はその JSON ファイルを読み込みます。

--- a/pybotters/ws.py
+++ b/pybotters/ws.py
@@ -381,6 +381,12 @@ class Heartbeat:
             await ws.send_str(f'{{"id": "{uuid.uuid4()}", "type": "ping"}}')
             await asyncio.sleep(15)
 
+    @staticmethod
+    async def okj(ws: aiohttp.ClientWebSocketResponse):
+        while not ws.closed:
+            await ws.send_str("ping")
+            await asyncio.sleep(15.0)
+
 
 class Auth:
     @staticmethod
@@ -649,6 +655,7 @@ class HeartbeatHosts:
         "contract.mexc.com": Heartbeat.mexc,
         "ws-api-spot.kucoin.com": Heartbeat.kucoin,
         "ws-api-futures.kucoin.com": Heartbeat.kucoin,
+        "connect.okcoin.jp": Heartbeat.okj,
     }
 
 

--- a/pybotters/ws.py
+++ b/pybotters/ws.py
@@ -11,6 +11,7 @@ import random
 import struct
 import time
 import uuid
+import zlib
 from dataclasses import dataclass
 from secrets import token_hex
 from typing import TYPE_CHECKING, Any, AsyncIterator, Awaitable, Generator, cast
@@ -576,6 +577,43 @@ class Auth:
         }
         await ws.send_json(msg)
 
+    @staticmethod
+    async def okj(ws: aiohttp.ClientWebSocketResponse):
+        key: str = ws._response._session.__dict__["_apis"][
+            AuthHosts.items[ws._response.url.host].name
+        ][0]
+        secret: bytes = ws._response._session.__dict__["_apis"][
+            AuthHosts.items[ws._response.url.host].name
+        ][1]
+        passphrase: bytes = ws._response._session.__dict__["_apis"][
+            AuthHosts.items[ws._response.url.host].name
+        ][2]
+
+        timestamp = str(time.time())
+        text = f"{timestamp}GET/users/self/verify"
+        sign = base64.b64encode(
+            hmac.new(secret, text.encode(), digestmod=hashlib.sha256).digest()
+        ).decode()
+        msg_to_send = {
+            "op": "login",
+            "args": [key, passphrase, timestamp, sign],
+        }
+        await ws.send_json(msg_to_send)
+        async for msg in ws:
+            if msg.type != aiohttp.WSMsgType.BINARY:
+                continue
+            try:
+                data = json.loads(zlib.decompress(msg.data, -zlib.MAX_WBITS))
+            except json.JSONDecodeError:
+                pass
+            else:
+                event = data.get("event")
+                if event == "error":
+                    logger.warning(data)
+                    break
+                elif event == "login":
+                    break
+
 
 @dataclass
 class Item:
@@ -632,6 +670,7 @@ class AuthHosts:
         "wspap.okx.com": Item("okx_demo", Auth.okx),
         "ws.bitget.com": Item("bitget", Auth.bitget),
         "contract.mexc.com": Item("mexc", Auth.mexc),
+        "connect.okcoin.jp": Item("okj", Auth.okj),
     }
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -108,6 +108,11 @@ def mock_session(mocker: pytest_mock.MockerFixture):
             b"r9ugGEq5pJkrBuqs6GYFgHFIgsPr4iAw06awzFByoZPRjTJs",
             "MyPassphrase123",
         ),
+        "okj": (
+            "NpuOBinRJMsSKHE38Gbf6MAm",
+            b"xNn5J6y2uSAOZNHOORX2f6hWdD8QqE2eW01KDrt4gq74Q7A6",
+            "MyPassphrase123",
+        ),
     }
     assert set(apis.keys()) == set(
         item.name if isinstance(item.name, str) else item.name.__name__
@@ -1365,6 +1370,92 @@ def test_kucoin_post(mock_session, mocker: pytest_mock.MockerFixture):
         "session": mock_session,
     }
     args = pybotters.auth.Auth.kucoin(args, kwargs)
+    assert args == expected_args
+    assert kwargs["data"]._value == expected_kwargs["data"]._value
+    assert kwargs["headers"] == expected_kwargs["headers"]
+
+
+@pytest.mark.freeze_time(datetime.datetime(2036, 2, 5, 18, 28, 16))
+def test_okj_get(mock_session, mocker: pytest_mock.MockerFixture):
+    args = (
+        "GET",
+        URL(
+            "https://www.okcoin.jp/api/spot/v3/orders?instrument_id=BTC-JPY&state=filled&limit=2&&after=2500723297223680"
+        ),
+    )
+    kwargs = {
+        "data": None,
+        "headers": CIMultiDict(),
+        "session": mock_session,
+    }
+    expected_args = (
+        "GET",
+        URL(
+            "https://www.okcoin.jp/api/spot/v3/orders?instrument_id=BTC-JPY&state=filled&limit=2&&after=2500723297223680"
+        ),
+    )
+    expected_kwargs = {
+        "data": aiohttp.formdata.FormData({})(),
+        "headers": CIMultiDict(
+            {
+                "OK-ACCESS-KEY": "NpuOBinRJMsSKHE38Gbf6MAm",
+                "OK-ACCESS-SIGN": "z2O3V5la0FP21wbxkoFr5f+HDvoiqnZ5Cklz814LWJE=",
+                "OK-ACCESS-TIMESTAMP": "2036-02-05T18:28:16.000Z",
+                "OK-ACCESS-PASSPHRASE": "MyPassphrase123",
+                "Content-Type": "application/json",
+            }
+        ),
+        "session": mock_session,
+    }
+    args = pybotters.auth.Auth.okj(args, kwargs)
+    assert args == expected_args
+    assert kwargs["data"]._value == expected_kwargs["data"]._value
+    assert kwargs["headers"] == expected_kwargs["headers"]
+
+
+@pytest.mark.freeze_time(datetime.datetime(2036, 2, 5, 18, 28, 16))
+def test_okj_post(mock_session, mocker: pytest_mock.MockerFixture):
+    args = ("POST", URL("https://www.okcoin.jp/api/spot/v3/orders"))
+    kwargs = {
+        "data": {
+            "type": "limit",
+            "side": "buy",
+            "instrument_id": "BTC-JPY",
+            "size": "0.001",
+            "client_oid": "oktspot79",
+            "price": "4638.51",
+            "notional": "",
+            "order_type": "3",
+        },
+        "headers": CIMultiDict(),
+        "session": mock_session,
+    }
+    expected_args = ("POST", URL("https://www.okcoin.jp/api/spot/v3/orders"))
+    expected_kwargs = {
+        "data": aiohttp.payload.JsonPayload(
+            {
+                "type": "limit",
+                "side": "buy",
+                "instrument_id": "BTC-JPY",
+                "size": "0.001",
+                "client_oid": "oktspot79",
+                "price": "4638.51",
+                "notional": "",
+                "order_type": "3",
+            }
+        ),
+        "headers": CIMultiDict(
+            {
+                "OK-ACCESS-KEY": "NpuOBinRJMsSKHE38Gbf6MAm",
+                "OK-ACCESS-SIGN": "V/csv742qfo7G7QAi81qQQik8KrEmwKh5xsTHIFlq2M=",
+                "OK-ACCESS-TIMESTAMP": "2036-02-05T18:28:16.000Z",
+                "OK-ACCESS-PASSPHRASE": "MyPassphrase123",
+                "Content-Type": "application/json",
+            }
+        ),
+        "session": mock_session,
+    }
+    args = pybotters.auth.Auth.okj(args, kwargs)
     assert args == expected_args
     assert kwargs["data"]._value == expected_kwargs["data"]._value
     assert kwargs["headers"] == expected_kwargs["headers"]

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -792,6 +792,7 @@ async def test_websocketqueue():
         (pybotters.ws.Heartbeat.bitget,),
         (pybotters.ws.Heartbeat.mexc,),
         (pybotters.ws.Heartbeat.kucoin,),
+        (pybotters.ws.Heartbeat.okj,),
     ],
 )
 async def test_heartbeat_text(mocker: pytest_mock.MockerFixture, test_input):


### PR DESCRIPTION
This pull request adds support for OKX (OKCoinJapan) authentication. It includes changes to the code that allow for authentication with OKX, including the necessary headers and signatures. This enables users to authenticate and make requests to the OKX API using the provided credentials.