### PR TITLE
Support BitTrade (Huobi Japan) Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ It has the following features, making it useful for developing a trading bot.
 | bitbank | ✅ | ✅ | [Link](https://github.com/bitbankinc/bitbank-api-docs) |
 | Coincheck | ✅ | ✅ | [Link](https://coincheck.com/ja/documents/exchange/api) |
 | OKJ | ✅ | Not yet | [Link](https://dev.okcoin.jp/en/) |
+| BitTrade | ✅ | Not yet | [Link](https://api-doc.bittrade.co.jp/) |
 | Bybit | ✅ | ✅ | [Link](https://bybit-exchange.github.io/docs/v5/intro) |
 | Binance | ✅ | ✅ | [Link](https://developers.binance.com/docs/binance-spot-api-docs/CHANGELOG) |
 | OKX | ✅ | ✅ | [Link](https://www.okx.com/docs-v5/en/) |

--- a/docs/exchanges.rst
+++ b/docs/exchanges.rst
@@ -185,6 +185,40 @@ DataStore
 未サポート。
 
 
+BitTrade
+--------
+
+https://api-doc.bittrade.co.jp/
+
+Authentication
+~~~~~~~~~~~~~~
+
+* API 認証情報
+    * ``{"bittrade": ["API_KEY", "API_SERCRET"]}``
+* HTTP 認証
+    HTTP リクエスト時に取引所が定める認証情報が自動設定されます。
+
+    https://api-doc.bittrade.co.jp/#4adc7a21f5
+* WebSocket 認証
+    WebSocket 接続時に取引所が定める認証情報の WebSocket メッセージが自動送信されます。
+
+    https://api-doc.bittrade.co.jp/#7a52d716ff
+
+WebSocket
+~~~~~~~~~
+
+* Ping-Pong
+    取引所が定める Ping-Pong メッセージが自動送信されます。
+
+    * https://api-doc.bittrade.co.jp/#401564b16d
+    * https://api-doc.bittrade.co.jp/#111d6cb2aa
+
+DataStore
+~~~~~~~~~
+
+未サポート。
+
+
 Bybit
 -----
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -372,6 +372,7 @@ OKX Demo trading          ``okx_demo``
 Phemex                    ``phemex``
 Phemex Testnet            ``phemex_testnet``
 OKJ                       ``okj``
+BitTrade                  ``bittrade``
 ========================= =========================
 
 また ``apis`` 引数に辞書オブジェクトではなく代わりに **JSON ファイルパス** を文字列として渡すことで、pybotters はその JSON ファイルを読み込みます。

--- a/pybotters/ws.py
+++ b/pybotters/ws.py
@@ -15,6 +15,7 @@ import zlib
 from dataclasses import dataclass
 from secrets import token_hex
 from typing import TYPE_CHECKING, Any, AsyncIterator, Awaitable, Generator, cast
+from urllib.parse import urlencode
 
 import aiohttp
 from aiohttp.http_websocket import json
@@ -620,6 +621,60 @@ class Auth:
                 elif event == "login":
                     break
 
+    @staticmethod
+    async def bittrade(ws: aiohttp.ClientWebSocketResponse):
+        method = "GET"
+        host = ws._response.url.host
+        path = ws._response.url.path
+
+        key: str = ws._response._session.__dict__["_apis"][
+            AuthHosts.items[ws._response.url.host].name
+        ][0]
+        secret: bytes = ws._response._session.__dict__["_apis"][
+            AuthHosts.items[ws._response.url.host].name
+        ][1]
+
+        timestamp = datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%S"
+        )
+        params = {
+            "accessKey": key,
+            "signatureMethod": "HmacSHA256",
+            "signatureVersion": "2.1",
+            "timestamp": timestamp,
+        }
+        params_str = urlencode(params)
+        sign_str = f"{method}\n{host}\n{path}\n{params_str}".encode()
+        signature = base64.b64encode(
+            hmac.new(secret, sign_str, hashlib.sha256).digest()
+        ).decode()
+
+        msg_to_send = {
+            "action": "req",
+            "ch": "auth",
+            "params": {
+                "authType": "api",
+                "accessKey": key,
+                "signatureMethod": params["signatureMethod"],
+                "signatureVersion": params["signatureVersion"],
+                "timestamp": timestamp,
+                "signature": signature,
+            },
+        }
+
+        await ws.send_json(msg_to_send)
+
+        async for msg in ws:
+            if msg.type != aiohttp.WSMsgType.TEXT:
+                continue
+
+            data: dict[str, Any] = msg.json()
+            if data.get("ch") == "auth":
+                if data.get("code") == 200:
+                    break
+                else:
+                    logger.warning(data)
+
 
 @dataclass
 class Item:
@@ -678,6 +733,7 @@ class AuthHosts:
         "ws.bitget.com": Item("bitget", Auth.bitget),
         "contract.mexc.com": Item("mexc", Auth.mexc),
         "connect.okcoin.jp": Item("okj", Auth.okj),
+        "api-cloud.bittrade.co.jp": Item("bittrade", Auth.bittrade),
     }
 
 

--- a/pybotters/ws.py
+++ b/pybotters/ws.py
@@ -388,6 +388,27 @@ class Heartbeat:
             await ws.send_str("ping")
             await asyncio.sleep(15.0)
 
+    @staticmethod
+    async def bittrade(ws: aiohttp.ClientWebSocketResponse):
+        # Retail
+        if ws._response.url.path == "/retail/ws":
+            while not ws.closed:
+                ts = int(time.time())
+                await ws.send_json({"action": 5, "ts": ts})
+                await asyncio.sleep(10.0)
+        # Public
+        elif ws._response.url.path == "/ws":
+            while not ws.closed:
+                ts = int(time.time() * 1000)
+                await ws.send_json({"pong": ts})
+                await asyncio.sleep(5.0)
+        # Private
+        elif ws._response.url.path == "/ws/v2":
+            while not ws.closed:
+                ts = int(time.time() * 1000)
+                await ws.send_json({"action": "pong", "data": {"ts": ts}})
+                await asyncio.sleep(20.0)
+
 
 class Auth:
     @staticmethod
@@ -711,6 +732,7 @@ class HeartbeatHosts:
         "ws-api-spot.kucoin.com": Heartbeat.kucoin,
         "ws-api-futures.kucoin.com": Heartbeat.kucoin,
         "connect.okcoin.jp": Heartbeat.okj,
+        "api-cloud.bittrade.co.jp": Heartbeat.bittrade,
     }
 
 

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -809,6 +809,27 @@ async def test_heartbeat_text(mocker: pytest_mock.MockerFixture, test_input):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "test_input",
+    [
+        (URL("wss://api-cloud.bittrade.co.jp/retail/ws")),
+        (URL("wss://api-cloud.bittrade.co.jp/ws")),
+        (URL("wss://api-cloud.bittrade.co.jp/ws/v2")),
+    ],
+)
+async def test_heartbeat_bittrade(mocker: pytest_mock.MockerFixture, test_input):
+    m_wsresp = AsyncMock()
+    m_wsresp._response.url = test_input
+    type(m_wsresp).closed = PropertyMock(side_effect=[False, True])
+    m_asyncio_sleep = mocker.patch("asyncio.sleep")
+
+    await asyncio.wait_for(pybotters.ws.Heartbeat.bittrade(m_wsresp), timeout=5.0)
+
+    assert m_wsresp.send_json.called
+    assert m_asyncio_sleep.called
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("test_input",),
     [
         (pybotters.ws.Heartbeat.binance,),


### PR DESCRIPTION
This pull request adds support for BitTrade authentication. It includes changes to the code that allow for the generation of a signature using the HMAC-SHA256 algorithm. The signature is then added to the request URL as a query parameter. This enables the authentication of requests made to the BitTrade API.