### PR TITLE
Support Python 3.13 and make 3.8 EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install Hatch
       uses: pypa/hatch@install
     - name: Build package
@@ -48,7 +48,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install Hatch
       uses: pypa/hatch@install
     - name: Run type checking
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -87,7 +87,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install Hatch
       uses: pypa/hatch@install
     - name: Download coverage data

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install Hatch
       uses: pypa/hatch@install
     - name: Build package

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ It has the following features, making it useful for developing a trading bot.
 
 ## 🐍 Requires
 
-Python 3.8+
+Python 3.9+
 
 ## 🔧 Installation
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -14,7 +14,7 @@ TL;DR
 **ワークフロー**
 
 0. (Optional) メンテナと議論が必要な場合 `Discussion <https://github.com/pybotters/pybotters/discussions>`_ または `Issue <https://github.com/pybotters/pybotters/pulls>`_ を作成する
-1. マシンをセットアップする (Python 3.8, Hatch ...)
+1. マシンをセットアップする (Python 3.9, Hatch ...)
 2. リポジトリを Fork する
 3. main ブランチを元に、変更する内容を表す名称のブランチ (トピックブランチ) を作成する
 4. あなたのアイディアをソースコードに反映する 💎💎
@@ -74,8 +74,8 @@ GitHub Codespaces は GitHub が提供するクラウドベースの開発環境
 Python
 ------
 
-pybotters は最小要求を **Python 3.8** としています。
-Python 3.8 の最新マイナーバージョンをインストールしてコーディングすることを推奨します。
+pybotters は最小要求を **Python 3.9** としています。
+Python 3.9 の最新マイナーバージョンをインストールしてコーディングすることを推奨します。
 
 Python のインストール方法は多岐にわたります。
 `こちらの記事 (python.jp) <https://www.python.jp/install/install.html>`__ を参考にするか、または次に紹介する **Hatch** を利用してください。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "pybotters"
 dynamic = ["version", "readme"]
 description = "An advanced API client for python crypto bot traders"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "MIT"
 keywords = ["aiohttp", "crypto", "exchange", "trading"]
 authors = [
@@ -16,11 +16,11 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "License :: OSI Approved :: MIT License",
   "Framework :: AsyncIO",
   "Framework :: aiohttp",
@@ -71,7 +71,7 @@ extra-dependencies = [
 
 [tool.hatch.envs.default]
 template = "hatch-test"
-python = "3.8"
+python = "3.9"
 dependencies = [
   "mypy>=1.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ extra-dependencies = [
   "pytest-freezer",
 ]
 
+[[tool.hatch.envs.hatch-test.matrix]]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
 [tool.hatch.envs.default]
 template = "hatch-test"
 python = "3.9"


### PR DESCRIPTION
1.We support Python 3.13.
2. We will discontinue support for Python 3.8, which has reached its end-of-life.
3. Therefore, the minimum required Python version is 3.9.
