### PR TITLE
Add a "dependencies" category to the auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -28,6 +28,9 @@ changelog:
     - title: Development
       labels:
         - release-development
+    - title: Dependencies
+      labels:
+        - dependencies
     - title: Other
       labels:
         - '*'


### PR DESCRIPTION
Since we have introduced dependabot, we need to categorise labels for it.