### PR TITLE
Improve events triggering CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,12 @@
 
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Remove CI triggering by push events to non-default branches. 

In the current configuration, both push and pull_request events are triggered and the pull request checks show duplicate jobs. This is very difficult to see:

![image](https://github.com/user-attachments/assets/d43420a4-015b-4ba5-9199-e97087bc5ee6)

Following the [GitHub template](https://github.com/actions/starter-workflows/blob/main/ci/python-package.yml), the only events that trigger CI are the push to main and the pull request. We also add a workflow_dispatch trigger to make it easier to run CI on Fork.