### PR TITLE
Add note on biFlyerDataStore handmade stores

### DIFF
--- a/docs/exchanges.rst
+++ b/docs/exchanges.rst
@@ -36,6 +36,16 @@ DataStore
 
 * :class:`.bitFlyerDataStore` (*JSON-RPC 2.0 over WebSocket* のみ)
 
+以下の DataStore に格納される値は pybotters による独自実装です。 また特定のキーのみが更新されます。
+    * :attr:`.bitFlyerDataStore.positions`
+        * ``size`` キーのみが更新されます。
+    * :attr:`.bitFlyerDataStore.collateral`
+        * ``collateral`` キーのみが更新されます。
+    * :attr:`.bitFlyerDataStore.balance`
+        * ``amount`` キーのみが更新されます。
+    .. warning::
+        bitFlyer の WebSocket チャンネル ``child_order_events`` は各種データを提供しておらず、計算の元となる約定情報のみを提供しています。 その為 ``bitFlyerDataStore`` は約定情報から独自に各種データを計算しています。 値が正確になるよう努めていますが、端数処理などの影響で実データとズレが生じる可能性があることに注意してください。 正確な値を必要とする場合は、HTTP API による :meth:`.bitFlyerDataStore.initialize` を利用してください。
+
 対応している WebSocket チャンネルはリファレンスの *ATTRIBUTES* をご覧ください。
 
 


### PR DESCRIPTION
Add a note clarifying the handling of collateral and specific keys in the DataStore implementation. Highlight potential discrepancies in data accuracy due to the limitations of the WebSocket channel.