### PR TITLE
Fix errors caused by aiohttp 3.11 updates

### DIFF
--- a/pybotters/ws.py
+++ b/pybotters/ws.py
@@ -6,6 +6,7 @@ import datetime
 import hashlib
 import hmac
 import inspect
+import json
 import logging
 import random
 import struct
@@ -18,7 +19,6 @@ from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlencode
 
 import aiohttp
-from aiohttp.http_websocket import json
 
 from .auth import Auth as _Auth
 

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -641,7 +641,9 @@ async def test_wsresponse_send_json():
     )
     await asyncio.wait_for(wsresp.send_json({"foo": "bar"}), timeout=5.0)
 
-    assert m_writer.send.call_args == call('{"foo": "bar"}', binary=ANY, compress=ANY)
+    assert m_writer.send_frame.call_args == call(
+        b'{"foo": "bar"}', aiohttp.WSMsgType.TEXT, compress=None
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Changes address compatibility issues arising from updates to the aiohttp library, including adjustments to JSON handling in WebSocket responses.

- Fix `json` import error
  ```
  ______________________________________________________________ ERROR collecting tests/test_ws.py ______________________________________________________________
  ImportError while importing test module '/workspaces/pybotters/tests/test_ws.py'.
  Hint: make sure your test modules/packages have valid Python names.
  Traceback:
  /home/codespace/.local/share/uv/python/cpython-3.9.20-linux-x86_64-gnu/lib/python3.9/importlib/__init__.py:127: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
  tests/test_ws.py:19: in <module>
      import pybotters
  pybotters/__init__.py:5: in <module>
      from .client import Client, FetchResult, NotJSONContent
  pybotters/client.py:16: in <module>
      from .ws import ClientWebSocketResponse, WebSocketApp
  pybotters/ws.py:21: in <module>
      from aiohttp.http_websocket import json
  E   ImportError: cannot import name 'json' from 'aiohttp.http_websocket' (/home/codespace/.cache/uv/archive-v0/rupRSxK7YKBsJipGX7xlv/lib/python3.9/site-packages/aiohttp/http_websocket.py)
  ```
- Fix internal implementation tests