### PR TITLE
Add direct dependencies requirements file for dependabot

### DIFF
--- a/requirements/dependencies.txt
+++ b/requirements/dependencies.txt
@@ -1,0 +1,2 @@
+aiohttp==3.11.7
+typing-extensions==4.12.2 ; python_version < "3.10"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,6 @@
 -e .
 
+-r dependencies.txt
 -r test.txt
 -r lint.txt
 -r typing.txt


### PR DESCRIPTION
Add a requirements/dependencies.txt file with direct dependencies for the project. dependabot periodically checks this and creates a PR. This will run CI, which can be useful for testing the health of the package by updating direct dependencies.

#332 and prevents libraries from breaking without your knowledge.