### PR TITLE
Update docs and resolve warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ It has the following features, making it useful for developing a trading bot.
 | MEXC | ✅ | No support | [Link](https://mexcdevelop.github.io/apidocs/spot_v3_en/) |
 | KuCoin | ✅ | ✅ | [Link](https://www.kucoin.com/docs/beginners/introduction) |
 | BitMEX | ✅ | ✅ | [Link](https://www.bitmex.com/app/apiOverview) |
-| Hyperliquid | ✅ | Not yet | [Link](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api) |
+| Hyperliquid | ✅ | Partially | [Link](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api) |
 
 ## 🐍 Requires
 

--- a/docs/exchanges.rst
+++ b/docs/exchanges.rst
@@ -43,6 +43,7 @@ DataStore
         * ``collateral`` キーのみが更新されます。
     * :attr:`.bitFlyerDataStore.balance`
         * ``amount`` キーのみが更新されます。
+
     .. warning::
         bitFlyer の WebSocket チャンネル ``child_order_events`` は各種データを提供しておらず、計算の元となる約定情報のみを提供しています。 その為 ``bitFlyerDataStore`` は約定情報から独自に各種データを計算しています。 値が正確になるよう努めていますが、端数処理などの影響で実データとズレが生じる可能性があることに注意してください。 正確な値を必要とする場合は、HTTP API による :meth:`.bitFlyerDataStore.initialize` を利用してください。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,3 +87,6 @@ ignore = ["E501"]
 [tool.mypy]
 packages = ["pybotters", "tests"]
 exclude = ["pybotters/_static_dependencies"]
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
- Fix support status for Hyperliquid DataStore in README.md
- Fix _Sphinx_ build warning
  > docs/exchanges.rst:46: WARNING: Bullet list ends without a blank line; unexpected unindent.
- Fix _pytest-asyncio_ warning
  > PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset. The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"