### PR TITLE
Fix Fatal Error：bad revision 'HEAD'

### DIFF
--- a/pybotters/_static_dependencies/ethereum/__init__.py
+++ b/pybotters/_static_dependencies/ethereum/__init__.py
@@ -1,0 +1,7 @@
+from .abi import *
+from .account import *
+from .typing import *
+from .utils import *
+from .hexbytes import *
+
+__all__ = [ 'account', 'typing', 'utils', 'abi', 'hexbytes' ]

--- a/pybotters/_static_dependencies/ethereum/__init__.py
+++ b/pybotters/_static_dependencies/ethereum/__init__.py
@@ -1,7 +1,0 @@
-from .abi import *
-from .account import *
-from .typing import *
-from .utils import *
-from .hexbytes import *
-
-__all__ = [ 'account', 'typing', 'utils', 'abi', 'hexbytes' ]

--- a/pybotters/_static_dependencies/toolz/__init__.py
+++ b/pybotters/_static_dependencies/toolz/__init__.py
@@ -22,5 +22,5 @@ from . import curried
 # functoolz._sigs.create_signature_registry()
 
 from ._version import get_versions
-__version__ = get_versions()['version']
+__version__ = '0+unknown'
 del get_versions

--- a/scripts/static-dependencies
+++ b/scripts/static-dependencies
@@ -15,11 +15,11 @@ curl -fL "$url" | tar -C downloads -xz
 rm -rf pybotters/_static_dependencies
 cp -rT "downloads/$version_dir/ccxt/static_dependencies" pybotters/_static_dependencies
 
-# Delete extra `*` imports
-echo -n > pybotters/_static_dependencies/ethereum/__init__.py
+# Patch toolz get_versions().
+sed -i -E "s/get_versions\(\)\['version'\]/'0+unknown'/" pybotters/_static_dependencies/toolz/__init__.py 
 # The following error will be suppressed:
 #   fatal: bad revision 'HEAD'
-# This appears to be caused by static dependencies running sub-processes.
+# This appears to be due to running sub-processes.
 # https://github.com/ccxt/ccxt/blob/4.3.77/python/ccxt/static_dependencies/toolz/__init__.py#L25
 
 rm -rf "downloads/$version_dir"

--- a/scripts/static-dependencies
+++ b/scripts/static-dependencies
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eux
 
 # Download static dependencies.
 
@@ -6,6 +6,20 @@
 # pybotters bundles ccxt's awesome static_dependencies to avoid additional dependencies.
 # This mainly includes authentication modules related to DEX and Ethereum.
 
-wget -O - https://files.pythonhosted.org/packages/0a/ef/c0032719c18766714eb4e8cf70ebe8a2724137bba6fa85c9e472ccf3c5fc/ccxt-4.3.77.tar.gz | tar -C downloads -xz
+url='https://files.pythonhosted.org/packages/0a/ef/c0032719c18766714eb4e8cf70ebe8a2724137bba6fa85c9e472ccf3c5fc/ccxt-4.3.77.tar.gz'
+version_dir=$(basename "$url" .tar.gz)
+
+mkdir -p downloads
+curl -fL "$url" | tar -C downloads -xz
+
 rm -rf pybotters/_static_dependencies
-cp -rT downloads/ccxt-4.3.77/ccxt/static_dependencies pybotters/_static_dependencies
+cp -rT "downloads/$version_dir/ccxt/static_dependencies" pybotters/_static_dependencies
+
+# Delete extra `*` imports
+echo -n > pybotters/_static_dependencies/ethereum/__init__.py
+# The following error will be suppressed:
+#   fatal: bad revision 'HEAD'
+# This appears to be caused by static dependencies running sub-processes.
+# https://github.com/ccxt/ccxt/blob/4.3.77/python/ccxt/static_dependencies/toolz/__init__.py#L25
+
+rm -rf "downloads/$version_dir"


### PR DESCRIPTION
Importing pybotters under certain conditions results in the following error in stdout:

1. `git init`
2. `pip install 'pybotters<=1.7.1'`
3. `python -c 'import pybotters`

```
fatal: bad revision 'HEAD'
```

This is due to vendor-linked static dependencies of ccxt.

Patch a function that has a problem with the vendor script.

I have reported the problem to Upstream: https://github.com/ccxt/ccxt/pull/24820