### PR TITLE
Fix flaky tests on WebSocket

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,4 +89,4 @@ packages = ["pybotters", "tests"]
 exclude = ["pybotters/_static_dependencies"]
 
 [tool.pytest.ini_options]
-asyncio_default_fixture_loop_scope = "module"
+asyncio_default_fixture_loop_scope = "function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,4 +89,4 @@ packages = ["pybotters", "tests"]
 exclude = ["pybotters/_static_dependencies"]
 
 [tool.pytest.ini_options]
-asyncio_default_fixture_loop_scope = "function"
+asyncio_default_fixture_loop_scope = "module"

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -375,6 +375,8 @@ async def test_websocketapp_functional(
         (await asyncio.wait_for(wsq.get(), timeout=5.0)),
         (await asyncio.wait_for(wsq.get(), timeout=5.0)),
     ]
+    wstask.cancel()
+    await asyncio.wait([wstask], timeout=5.0)
 
     assert received_messages == [send_message, send_message]
     assert wstask.cancelled()
@@ -385,9 +387,6 @@ async def test_websocketapp_functional(
         call(20),
         call(30),
     ]
-
-    wstask.cancel()
-    await asyncio.wait([wstask], timeout=5.0)
 
 
 @pytest_asyncio.fixture
@@ -443,14 +442,13 @@ async def test_websocketapp_ensure_open_hdlr(
     received_messages = [
         (await asyncio.wait_for(wsq.get(), timeout=5.0)),
     ]
+    wstask.cancel()
+    await asyncio.wait([wstask], timeout=5.0)
 
     assert received_messages == [{"data": "spam"}]
     assert wstask.cancelled()
 
     assert caplog.records == []  # No handler errors
-
-    wstask.cancel()
-    await asyncio.wait([wstask], timeout=5.0)
 
 
 def test_heartbeathosts():

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -377,6 +377,7 @@ async def test_websocketapp_functional(
     ]
 
     assert received_messages == [send_message, send_message]
+    assert wstask.cancelled()
 
     assert m_random.call_count == 1
     assert m_asyncio_sleep.call_args_list == [
@@ -444,6 +445,7 @@ async def test_websocketapp_ensure_open_hdlr(
     ]
 
     assert received_messages == [{"data": "spam"}]
+    assert wstask.cancelled()
 
     assert caplog.records == []  # No handler errors
 

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -448,7 +448,8 @@ async def test_websocketapp_ensure_open_hdlr(
     assert received_messages == [{"data": "spam"}]
     assert wstask.cancelled()
 
-    assert caplog.records == []  # No handler errors
+    records = [x for x in caplog.records if x.name == "pybotters.ws"]
+    assert records == []  # No handler errors
 
 
 def test_heartbeathosts():

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -377,7 +377,6 @@ async def test_websocketapp_functional(
     ]
 
     assert received_messages == [send_message, send_message]
-    assert wstask.cancelled()
 
     assert m_random.call_count == 1
     assert m_asyncio_sleep.call_args_list == [
@@ -445,7 +444,6 @@ async def test_websocketapp_ensure_open_hdlr(
     ]
 
     assert received_messages == [{"data": "spam"}]
-    assert wstask.cancelled()
 
     assert caplog.records == []  # No handler errors
 

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -375,8 +375,6 @@ async def test_websocketapp_functional(
         (await asyncio.wait_for(wsq.get(), timeout=5.0)),
         (await asyncio.wait_for(wsq.get(), timeout=5.0)),
     ]
-    wstask.cancel()
-    await asyncio.wait([wstask], timeout=5.0)
 
     assert received_messages == [send_message, send_message]
     assert wstask.cancelled()
@@ -387,6 +385,9 @@ async def test_websocketapp_functional(
         call(20),
         call(30),
     ]
+
+    wstask.cancel()
+    await asyncio.wait([wstask], timeout=5.0)
 
 
 @pytest_asyncio.fixture
@@ -442,13 +443,14 @@ async def test_websocketapp_ensure_open_hdlr(
     received_messages = [
         (await asyncio.wait_for(wsq.get(), timeout=5.0)),
     ]
-    wstask.cancel()
-    await asyncio.wait([wstask], timeout=5.0)
 
     assert received_messages == [{"data": "spam"}]
     assert wstask.cancelled()
 
     assert caplog.records == []  # No handler errors
+
+    wstask.cancel()
+    await asyncio.wait([wstask], timeout=5.0)
 
 
 def test_heartbeathosts():


### PR DESCRIPTION
Tests may fail for no reason ...
```
>       assert caplog.records == []  # No handler errors
E       assert [<LogRecord: ...95854b0620>">] == []
E         
E         Left contains one more item: <LogRecord: asyncio, 40, /usr/lib/python3.12/asyncio/base_events.py, 1821, "Unclosed client session\nclient_session: <aiohttp.client.ClientSession object at 0x7f95854b0620>">
E         
E         Full diff:
E         - []
E         + [
E         +     <LogRecord: asyncio, 40, /usr/lib/python3.12/asyncio/base_events.py, 1821, "Unclosed client session
E         + client_session: <aiohttp.client.ClientSession object at 0x7f95854b0620>">,
E         + ]
```

Assertions will be put off.