### PR TITLE
Fix Hyperliquid docs example

### DIFF
--- a/docs/exchanges.rst
+++ b/docs/exchanges.rst
@@ -577,8 +577,8 @@ Authentication
 ~~~~~~~~~~~~~~
 
 * API 認証情報
-    * ``{"hyperliquid": ["SECRET_KEY"]}`` (Mainnet)
-    * ``{"hyperliquid_testnet": ["SECRET_KEY"]}`` (Testnet)
+    * ``{"hyperliquid": ["PRIVATE_KEY"]}`` (Mainnet)
+    * ``{"hyperliquid_testnet": ["PRIVATE_KEY"]}`` (Testnet)
 * HTTP 認証
     `Exchange endpoint <https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint>`_ (``/exchange``) へのリクエストに対して以下の Request Body を省略することができます。 省略した場合、以下の値が自動設定されます。
 

--- a/examples/order/hyperliquid.py
+++ b/examples/order/hyperliquid.py
@@ -24,7 +24,7 @@ def normalize_number(number: str) -> str:
 
     Hyperliquid API expects normalized numbers. Otherwise, `L1 error` will occur.
     """
-    return str(Decimal(number).normalize())
+    return format(Decimal(number).normalize(), "f")
 
 
 async def main() -> None:

--- a/examples/order/hyperliquid.py
+++ b/examples/order/hyperliquid.py
@@ -13,8 +13,8 @@ from pprint import pprint
 
 import pybotters
 
-# Your secret key: 0x00000...
-HYPERLIQUID_TESTNET_SECRET_KEY = os.environ["HYPERLIQUID_TESTNET_SECRET_KEY"]
+# Your private key: 0x00000...
+HYPERLIQUID_TESTNET_PRIVATE_KEY = os.environ["HYPERLIQUID_TESTNET_PRIVATE_KEY"]
 
 
 def normalize_number(number: str) -> str:
@@ -31,12 +31,12 @@ async def main() -> None:
     """Place a limit order in Hyperliquid Testnet.
 
     [!WARNING]
-    Please change the secret key, target asset, and limit price, etc.
+    Please change the private key, target asset, and limit price, etc.
     Default: ETH, buy, 3300, 0.1
     """
     apis = {
         # Mainnet is "hyperliquid"
-        "hyperliquid_testnet": [HYPERLIQUID_TESTNET_SECRET_KEY],
+        "hyperliquid_testnet": [HYPERLIQUID_TESTNET_PRIVATE_KEY],
     }
     base_url = "https://api.hyperliquid-testnet.xyz"
     async with pybotters.Client(apis=apis, base_url=base_url) as client:

--- a/pybotters/auth.py
+++ b/pybotters/auth.py
@@ -489,7 +489,7 @@ class Auth:
         data: dict[str, Any] = kwargs["data"] or {}
 
         session: aiohttp.ClientSession = kwargs["session"]
-        secret_key: str = session.__dict__["_apis"][Hosts.items[url.host].name][0]
+        private_key: str = session.__dict__["_apis"][Hosts.items[url.host].name][0]
 
         if url.path.startswith("/info"):
             return args
@@ -515,7 +515,7 @@ class Auth:
                 eip712_typed_data = hyperliquid.construct_user_signed_action(action)
                 data["action"] = eip712_typed_data[2]  # MessageData
 
-            signature = hyperliquid.sign_typed_data(secret_key, *eip712_typed_data)
+            signature = hyperliquid.sign_typed_data(private_key, *eip712_typed_data)
             data["signature"] = signature
 
         if data:


### PR DESCRIPTION
1. Fix Decimal formatting
2. Fix terminology to "private key"

   docs and internal code