### PR TITLE
Update documentation build environment

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,17 @@
 version: 2
 
 build:
-  os: "ubuntu-22.04"
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
-  commands:
-    - asdf plugin add uv
-    - asdf install uv latest
-    - asdf global uv latest
-    - uv run --with-requirements requirements/docs.txt -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
+    python: "3.13"
+  jobs:
+    create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+      - uv venv --python 3.13
+    install:
+      - uv pip install -r requirements/docs.txt
+    build:
+      html:
+        - ./scripts/docs

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,5 @@
 furo==2024.8.6
 sphinx==7.4.7
-sphinx-autobuild<=2024.2.4
+sphinx-autobuild==2024.10.3
 sphinx-copybutton==0.5.2
 sphinx-new-tab-link==0.6.1

--- a/scripts/docs
+++ b/scripts/docs
@@ -7,4 +7,5 @@ uv run \
     --with-requirements requirements/docs.txt \
     --isolated \
     --no-project \
-    sphinx-build -M html docs docs/_build
+    --python 3.13 \
+    sphinx-build -T -b html docs "${READTHEDOCS_OUTPUT:-docs/_build}/html"

--- a/scripts/serve
+++ b/scripts/serve
@@ -7,4 +7,5 @@ uv run \
     --with-requirements requirements/docs.txt \
     --isolated \
     --no-project \
+    --python 3.13 \
     sphinx-autobuild docs docs/_build/html


### PR DESCRIPTION
Update the documentation build environment to Python 3.13 in order to update to Sphinx 8.x (#382). Previously the project’s minimum requirement was Python 3.9, but Sphinx 8.x requires Python >3.10.

The configuration of Read the Docs follows the improvements in readthedocs/readthedocs.org#11900.