### PR TITLE
Fix CI timeout errors for aiohttp 3.11.13

### DIFF
--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -432,7 +432,7 @@ async def test_websocketapp_ensure_open_hdlr(
             ws = await client.ws_connect(
                 f"ws://localhost:{test_ping_pong_server.port}/ws",
                 hdlr_json=wsq.onmessage,
-                heartbeat=None,
+                heartbeat=10.0,
                 autoping=True,
             )
             await ws.heartbeat(0.1)


### PR DESCRIPTION
Error log:
```log
2025-02-25T13:53:14.7711737Z The above exception was the direct cause of the following exception:
2025-02-25T13:53:14.7712135Z 
2025-02-25T13:53:14.7712429Z test_ping_pong_server = <aiohttp.test_utils.TestServer object at 0x7f93f0e3fa30>
2025-02-25T13:53:14.7713194Z caplog = <_pytest.logging.LogCaptureFixture object at 0x7f93f0fdb0d0>
2025-02-25T13:53:14.7713597Z 
2025-02-25T13:53:14.7713729Z     @pytest.mark.asyncio
2025-02-25T13:53:14.7714096Z     async def test_websocketapp_ensure_open_hdlr(
2025-02-25T13:53:14.7714872Z         test_ping_pong_server: TestServer, caplog: pytest.LogCaptureFixture
2025-02-25T13:53:14.7715368Z     ):
2025-02-25T13:53:14.7715656Z         wsq = pybotters.WebSocketQueue()
2025-02-25T13:53:14.7716020Z     
2025-02-25T13:53:14.7716298Z         async def message_ping_pong():
2025-02-25T13:53:14.7716709Z             async with pybotters.Client() as client:
2025-02-25T13:53:14.7717122Z                 ws = await client.ws_connect(
2025-02-25T13:53:14.7717606Z                     f"ws://localhost:{test_ping_pong_server.port}/ws",
2025-02-25T13:53:14.7718082Z                     hdlr_json=wsq.onmessage,
2025-02-25T13:53:14.7718469Z                     heartbeat=None,
2025-02-25T13:53:14.7718831Z                     autoping=True,
2025-02-25T13:53:14.7719372Z                 )
2025-02-25T13:53:14.7719693Z                 await ws.heartbeat(0.1)
2025-02-25T13:53:14.7720071Z                 await ws.wait()
2025-02-25T13:53:14.7720379Z     
2025-02-25T13:53:14.7720703Z         wstask = asyncio.create_task(message_ping_pong())
2025-02-25T13:53:14.7721153Z         received_messages = [
2025-02-25T13:53:14.7721551Z >           (await asyncio.wait_for(wsq.get(), timeout=5.0)),
2025-02-25T13:53:14.7721957Z         ]
2025-02-25T13:53:14.7722105Z 
2025-02-25T13:53:14.7722226Z tests/test_ws.py:443: 
```