### PR TITLE
Fix {'event': 'error', 'code': 30003, 'msg': 'INVALID op:login'} on Bitget Public WebSocket

### DIFF
--- a/pybotters/ws.py
+++ b/pybotters/ws.py
@@ -546,6 +546,9 @@ class Auth:
 
     @staticmethod
     async def bitget(ws: aiohttp.ClientWebSocketResponse):
+        if "public" in ws._response.url.parts:
+            return
+
         key: str = ws._response._session.__dict__["_apis"][
             AuthHosts.items[ws._response.url.host].name
         ][0]


### PR DESCRIPTION
Fixes #389