### PR TITLE
Allow optional ws argument in DataStore onmessage

### DIFF
--- a/pybotters/models/binance.py
+++ b/pybotters/models/binance.py
@@ -115,7 +115,7 @@ class BinanceDataStoreBase(DataStoreCollection):
             resp.url.query["symbol"], resp.url.query["interval"], data
         )
 
-    def _onmessage(self, msg: Any, ws: ClientWebSocketResponse) -> None:
+    def _onmessage(self, msg: Any, ws: ClientWebSocketResponse | None = None) -> None:
         if "error" in msg:
             logger.warning(msg)
         if "result" not in msg:

--- a/pybotters/models/bitbank.py
+++ b/pybotters/models/bitbank.py
@@ -18,7 +18,7 @@ class bitbankDataStore(DataStoreCollection):
         self._create("depth", datastore_class=Depth)
         self._create("ticker", datastore_class=Ticker)
 
-    def _onmessage(self, msg: str, ws: ClientWebSocketResponse) -> None:
+    def _onmessage(self, msg: str, ws: ClientWebSocketResponse | None = None) -> None:
         if msg.startswith("42"):
             data_json = json.loads(msg[2:])
             room_name = data_json[1]["room_name"]

--- a/pybotters/models/bitget.py
+++ b/pybotters/models/bitget.py
@@ -47,7 +47,7 @@ class BitgetDataStore(DataStoreCollection):
                         f"Data: {data}"
                     )
 
-    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse) -> None:
+    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse | None = None) -> None:
         if "arg" in msg and "data" in msg:
             channel = msg["arg"].get("channel")
             if channel == "trade":

--- a/pybotters/models/bitget_v2.py
+++ b/pybotters/models/bitget_v2.py
@@ -27,7 +27,7 @@ class BitgetV2DataStore(DataStoreCollection):
         self._create("orders-algo", datastore_class=OrdersAlgo)
         self._create("positions-history", datastore_class=PositionsHistory)
 
-    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse) -> None:
+    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse | None = None) -> None:
         data = msg.get("data")
         if data is not None:
             channel: str = msg["arg"]["channel"]

--- a/pybotters/models/bitmex.py
+++ b/pybotters/models/bitmex.py
@@ -37,7 +37,7 @@ class BitMEXDataStore(DataStoreCollection):
         self._create("position", datastore_class=DataStore)
         self._create("wallet", datastore_class=DataStore)
 
-    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse) -> None:
+    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse | None = None) -> None:
         if "error" in msg:
             logger.warning(msg)
         if "table" in msg:

--- a/pybotters/models/bybit.py
+++ b/pybotters/models/bybit.py
@@ -65,7 +65,7 @@ class BybitDataStore(DataStoreCollection):
                 if target_onresponse := getattr(self[topic], "_onresponse", None):
                     target_onresponse(resp.url, data)
 
-    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse) -> None:
+    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse | None = None) -> None:
         if "success" in msg:
             if not msg["success"]:
                 logger.warning(msg)

--- a/pybotters/models/coincheck.py
+++ b/pybotters/models/coincheck.py
@@ -33,7 +33,7 @@ class CoincheckDataStore(DataStoreCollection):
                 pair = resp.url.query.get("pair")
                 self.orderbook._onresponse(pair, data)
 
-    def _onmessage(self, msg: Any, ws: ClientWebSocketResponse) -> None:
+    def _onmessage(self, msg: Any, ws: ClientWebSocketResponse | None = None) -> None:
         first_item = next(iter(msg), None)
         if isinstance(first_item, list):
             self.trades._onmessage(msg)

--- a/pybotters/models/gmocoin.py
+++ b/pybotters/models/gmocoin.py
@@ -182,7 +182,7 @@ class GMOCoinDataStore(DataStoreCollection):
                 self.token = data["data"]
                 asyncio.create_task(self._token(resp.__dict__["_raw_session"]))
 
-    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse) -> None:
+    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse | None = None) -> None:
         if "error" in msg:
             logger.warning(msg)
         if "channel" in msg:

--- a/pybotters/models/hyperliquid.py
+++ b/pybotters/models/hyperliquid.py
@@ -20,7 +20,7 @@ class HyperliquidDataStore(DataStoreCollection):
         self._create("trades", datastore_class=Trades)
         # TODO: Add other data streams
 
-    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse) -> None:
+    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse | None = None) -> None:
         channel = msg.get("channel")
 
         if channel == "l2Book":

--- a/pybotters/models/kucoin.py
+++ b/pybotters/models/kucoin.py
@@ -73,7 +73,7 @@ class KuCoinDataStore(DataStoreCollection):
                     raise RuntimeError(f"Failed to get a websocket endpoint: {data}")
                 self._endpoint = self._create_endpoint(data["data"])
 
-    def _onmessage(self, msg: Any, ws: ClientWebSocketResponse) -> None:
+    def _onmessage(self, msg: Any, ws: ClientWebSocketResponse | None = None) -> None:
         if "topic" in msg:
             topic = msg["topic"]
             if (

--- a/pybotters/models/legacy/gmocoin.py
+++ b/pybotters/models/legacy/gmocoin.py
@@ -629,7 +629,7 @@ class GMOCoinDataStore(DataStoreCollection):
                 self.token = data["data"]
                 asyncio.create_task(self._token(resp.__dict__["_raw_session"]))
 
-    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse) -> None:
+    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse | None = None) -> None:
         if "error" in msg:
             logger.warning(msg)
         if "channel" in msg:

--- a/pybotters/models/okx.py
+++ b/pybotters/models/okx.py
@@ -62,7 +62,7 @@ class OKXDataStore(DataStoreCollection):
                 self.ordersalgo._onresponse(data["data"])
                 self.algoadvance._onresponse(data["data"])
 
-    def _onmessage(self, msg: Any, ws: ClientWebSocketResponse) -> None:
+    def _onmessage(self, msg: Any, ws: ClientWebSocketResponse | None = None) -> None:
         if "event" in msg:
             if msg["event"] == "error":
                 logger.warning(msg)

--- a/pybotters/models/phemex.py
+++ b/pybotters/models/phemex.py
@@ -51,7 +51,7 @@ class PhemexDataStore(DataStoreCollection):
                 if symbol:
                     self.kline._onresponse(symbol, data)
 
-    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse) -> None:
+    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse | None = None) -> None:
         if not msg.get("id"):
             if "trades" in msg or "trades_p" in msg:
                 self.trade._onmessage(msg)

--- a/pybotters/store.py
+++ b/pybotters/store.py
@@ -397,10 +397,10 @@ class DataStoreCollection:
     def _get(self, name: str, type_: type[DataStore] | None = None) -> DataStore | None:
         return self._stores.get(name)
 
-    def _onmessage(self, msg: Any, ws: ClientWebSocketResponse) -> None:
+    def _onmessage(self, msg: Any, ws: ClientWebSocketResponse | None = None) -> None:
         print(msg)
 
-    def onmessage(self, msg: Any, ws: ClientWebSocketResponse) -> None:
+    def onmessage(self, msg: Any, ws: ClientWebSocketResponse | None = None) -> None:
         """WebSocket message handler.
 
         :meth:`.Client.ws_connect` に渡すコールバックです。


### PR DESCRIPTION
DataStore's `ws` argument is now optional.

```python
store = pybotters.DataStoreCollection()
store.onmessage({"foo": "bar"})
```