### PR TITLE
Prefer the target absolute URL to the base URL in the client request

### DIFF
--- a/pybotters/client.py
+++ b/pybotters/client.py
@@ -6,6 +6,7 @@ import logging
 import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
+from urllib.parse import urlparse
 
 import aiohttp
 from aiohttp import hdrs
@@ -78,9 +79,13 @@ class Client:
         auth: type[Auth] | None = Auth,
         **kwargs: Any,
     ) -> RequestContextManager:
+        if urlparse(url).scheme:
+            target_url = url
+        else:
+            target_url = self._base_url + url
         return self._session.request(
             method=method,
-            url=self._base_url + url,
+            url=target_url,
             params=params,
             data=data,
             auth=auth,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -61,7 +61,7 @@ async def test_client_base_url() -> None:
 
     @base_routes.get("/")
     async def base_hello(request: web.Request) -> web.Response:
-        return web.Response(text="Hello from base")
+        return web.Response(text="Hello from base")  # pragma: no cover
 
     base_app = web.Application()
     base_app.add_routes(base_routes)


### PR DESCRIPTION
The following code will be available:
```python
base_url = "https://foo.example.com"
alt_url = "https://bar.example.com"
async with pybotters.Client(base_url=base_url) as client:
    r = await client.fetch("GET", alt_url)
```

Previously, the following error occurred:
```
aiohttp.client_exceptions.InvalidUrlClientError: http://127.0.0.1:44800http://127.0.0.1:45678
```