### PR TITLE
Fix WebSocket 403 error for Hyperliquid

### DIFF
--- a/pybotters/auth.py
+++ b/pybotters/auth.py
@@ -491,7 +491,7 @@ class Auth:
         session: aiohttp.ClientSession = kwargs["session"]
         private_key: str = session.__dict__["_apis"][Hosts.items[url.host].name][0]
 
-        if url.path.startswith("/info"):
+        if url.path.startswith(("/info", "/ws")):
             return args
 
         action: dict[str, Any] = data.get("action", {})


### PR DESCRIPTION
Fixes #419

This pull request includes a small but important change to the `hyperliquid` function in `pybotters/auth.py`. The change expands the condition for returning `args` to include URLs whose paths start with `"/ws"` in addition to `"/info"`.