### PR TITLE
Fix type annotations for hdlr_* arguments in Client.ws_connect

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -157,7 +157,7 @@ Multiple WebSocket senders/handlers
 Current WebSocket connection
 ----------------------------
 
-:attr:`.WebSocketApp.current_ws` プロパティから現在接続中の WebSocket コネクションにアクセスできます。 この変数は :class:`pybotters.ClientWebSocketResponse` 型であり、 `aiohttp.ClientWebSocketResponse <https://docs.aiohttp.org/en/stable/client_reference.html#clientwebsocketresponse>`_ のサブクラスです。
+:attr:`.WebSocketApp.current_ws` プロパティから現在接続中の WebSocket コネクションにアクセスできます。 この変数は :class:`pybotters.ClientWebSocketResponse` 型であり、 :class:`aiohttp.ClientWebSocketResponse` のサブクラスです。
 このクラスから 1 回限りの WebSocket メッセージ送信などができます。
 これは取引所 WebSocket API で注文の作成に対応しているケースなどで有用です。
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -157,9 +157,7 @@ Multiple WebSocket senders/handlers
 Current WebSocket connection
 ----------------------------
 
-:attr:`.WebSocketApp.current_ws` プロパティから aiohttp の WebSocket クラス
-`ClientWebSocketResponse <https://docs.aiohttp.org/en/stable/client_reference.html#clientwebsocketresponse>`_
-にアクセスできます。
+:attr:`.WebSocketApp.current_ws` プロパティから現在接続中の WebSocket コネクションにアクセスできます。 この変数は :class:`pybotters.ClientWebSocketResponse` 型であり、 `aiohttp.ClientWebSocketResponse <https://docs.aiohttp.org/en/stable/client_reference.html#clientwebsocketresponse>`_ のサブクラスです。
 このクラスから 1 回限りの WebSocket メッセージ送信などができます。
 これは取引所 WebSocket API で注文の作成に対応しているケースなどで有用です。
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,6 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_new_tab_link",
     "sphinx.ext.napoleon",
-    "sphinx.ext.intersphinx",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,11 +53,6 @@ language = "ja"
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".venv"]
 
-intersphinx_mapping = {
-    "python": ("https://docs.python.org/3/", None),
-    "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
-}
-intersphinx_disabled_domains = ["std"]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_new_tab_link",
     "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -53,6 +54,11 @@ language = "ja"
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".venv"]
 
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
+}
+intersphinx_disabled_domains = ["std"]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -27,6 +27,7 @@ WebSocket API Returns
    :toctree: generated
 
    pybotters.WebSocketApp
+   pybotters.ClientWebSocketResponse
 
 
 Common WebSocket handlers

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -267,7 +267,7 @@ WebSocket API
     これらの引数は送信するメッセージをリストで括ることで複数のメッセージを送信できます (:ref:`multiple-websocket-senders-handlers`) 。
 * WebSocket メッセージの受信
     ``hdlr_str``, ``hdlr_bytes``, ``hdlr_json`` 引数で受信した WebSocket メッセージのハンドラ (コールバック) を指定します。
-    指定するハンドラの第 1 引数をそれぞれ :class:`str`, :class:`bytes`, :data:`typing.Any` を取る必要があります。 第 2 引数は :class:`.ClientWebSocketResponse` ``| None`` を取る必要があります。
+    指定するハンドラの第 1 引数はそれぞれ :class:`str`, :class:`bytes`, :data:`typing.Any` を取る必要があります。 第 2 引数は :class:`.ClientWebSocketResponse` または ``None`` を取る必要があります。
     上記のコードでは無名関数をハンドラに指定して WebSocket メッセージを標準出力しています。
 
     pybotters には組み込みのハンドラとして、汎用性の高い :ref:`websocketqueue` や、 :ref:`取引所固有の DataStore <exchange-specific-datastore>` があります。

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -267,7 +267,7 @@ WebSocket API
     これらの引数は送信するメッセージをリストで括ることで複数のメッセージを送信できます (:ref:`multiple-websocket-senders-handlers`) 。
 * WebSocket メッセージの受信
     ``hdlr_str``, ``hdlr_bytes``, ``hdlr_json`` 引数で受信した WebSocket メッセージのハンドラ (コールバック) を指定します。
-    指定するハンドラは第 1 引数 ``msg: aiohttp.WSMessage`` 第 2 引数 ``ws: aiohttp.ClientWebSocketResponse`` を取る必要があります。
+    指定するハンドラの第 1 引数をそれぞれ :class:`str`, :class:`bytes`, :data:`typing.Any` を取る必要があります。 第 2 引数は :class:`.ClientWebSocketResponse` ``| None`` を取る必要があります。
     上記のコードでは無名関数をハンドラに指定して WebSocket メッセージを標準出力しています。
 
     pybotters には組み込みのハンドラとして、汎用性の高い :ref:`websocketqueue` や、 :ref:`取引所固有の DataStore <exchange-specific-datastore>` があります。

--- a/pybotters/__init__.py
+++ b/pybotters/__init__.py
@@ -21,7 +21,7 @@ from .models.kucoin import KuCoinDataStore
 from .models.okx import OKXDataStore
 from .models.phemex import PhemexDataStore
 from .store import DataStore, DataStoreCollection, StoreChange, StoreStream
-from .ws import WebSocketApp, WebSocketQueue
+from .ws import ClientWebSocketResponse, WebSocketApp, WebSocketQueue
 
 __all__: tuple[str, ...] = (
     # version
@@ -31,6 +31,7 @@ __all__: tuple[str, ...] = (
     "FetchResult",
     "NotJSONContent",
     # ws
+    "ClientWebSocketResponse",
     "WebSocketApp",
     "WebSocketQueue",
     # store

--- a/pybotters/typedefs.py
+++ b/pybotters/typedefs.py
@@ -7,8 +7,10 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Coroutine
     from contextlib import AbstractAsyncContextManager
 
+    import aiohttp
     from _typeshed import StrOrBytesPath as StrOrBytesPath
-    from aiohttp.client_ws import ClientResponse, ClientWebSocketResponse
+
+    from .ws import ClientWebSocketResponse
 
     if sys.version_info >= (3, 10):
         from typing import TypeAlias
@@ -16,7 +18,9 @@ if TYPE_CHECKING:
         from typing_extensions import TypeAlias
 
     class RequestContextManager(
-        Awaitable[ClientResponse], AbstractAsyncContextManager[ClientResponse], Protocol
+        Awaitable[aiohttp.ClientResponse],
+        AbstractAsyncContextManager[aiohttp.ClientResponse],
+        Protocol,
     ): ...
 
     APICredentialsDict: TypeAlias = dict[str, list[str]]

--- a/pybotters/ws.py
+++ b/pybotters/ws.py
@@ -770,6 +770,10 @@ class AuthHosts:
 
 
 class ClientWebSocketResponse(aiohttp.ClientWebSocketResponse):
+    """Class for handling client-side websockets.
+
+    This class is a subclass of :class:`aiohttp.ClientWebSocketResponse`."""
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if self._response.url.host in HeartbeatHosts.items:
@@ -792,6 +796,7 @@ class ClientWebSocketResponse(aiohttp.ClientWebSocketResponse):
             await self.__dict__["_authtask"]
 
     async def send_str(self, *args, **kwargs) -> None:
+        """Send *data* to peer as :attr:`aiohttp.WSMsgType.TEXT` message."""
         if self._response.url.host not in RequestLimitHosts.items:
             await super().send_str(*args, **kwargs)
         else:
@@ -799,6 +804,7 @@ class ClientWebSocketResponse(aiohttp.ClientWebSocketResponse):
             await RequestLimitHosts.items[self._response.url.host](self, super_send_str)
 
     async def send_json(self, *args, **kwargs) -> None:
+        """Send *data* to peer as JSON string."""
         if (
             (kwargs.pop("auth", _Auth) is _Auth)
             and (self._response.url.host in MessageSignHosts.items)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -332,3 +332,14 @@ async def test_client_ws_connect(mocker: pytest_mock.MockerFixture):
         },
     ]
     assert ret == m.return_value
+
+
+@pytest.mark.asyncio
+async def test_client_ws_connect_hdlr_type(mocker: pytest_mock.MockerFixture) -> None:
+    m = mocker.patch("pybotters.client.WebSocketApp", new_callable=AsyncMock)
+
+    async with pybotters.Client() as client:
+        store = pybotters.DataStoreCollection()
+        await client.ws_connect("ws://example.com", hdlr_json=store.onmessage)
+
+    assert m.called


### PR DESCRIPTION
## Summary

This pull request fixes incorrect type annotations for handler arguments (`hdlr_*`) in the `Client.ws_connect` method. Previously, handlers were expected to accept `aiohttp.ClientWebSocketResponse`, but the actual type is `pybotters.ClientWebSocketResponse`. This mismatch caused type errors when using features like `DataStoreCollection`.

For example, the following code produced a type error:

```py
client: pybotters.Client
store: pybotters.DataStoreCollection
await client.ws_connect("...", hdlr_json=store.onmessage)
```
```py
tests/test_client.py:341: error: Argument "hdlr_json" to "ws_connect" of "Client" has incompatible type "Callable[[Any, Optional[pybotters.ws.ClientWebSocketResponse]], None]"; expected "Union[Callable[[Any, aiohttp.client_ws.ClientWebSocketResponse], None], list[Callable[[Any, aiohttp.client_ws.ClientWebSocketResponse], None]], None]"  [arg-type]
```

## Details

- Updated all relevant type annotations to use `pybotters.ClientWebSocketResponse` for WebSocket handlers.
- Made `ClientWebSocketResponse` publicly available in the package.
- Revised documentation to reflect the correct handler signatures and the public API.

## Motivation

These changes improve type safety and developer experience, ensuring that users receive accurate type hints and documentation when implementing WebSocket handlers.