### PR TITLE
Improve Sphinx cross-references for aiohttp classes and methods

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -248,7 +248,7 @@ Automatic WebSocket heartbeat
 
     前述の通りハートビートはデフォルトで有効になっており、トレード bot のユースケースでこれを無効にすることは推奨されません。
 
-    なお、このハートビート機能は `aiohttp の実装 <https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientSession.ws_connect>`_ によるものです。
+    なお、このハートビート機能は aiohttp の実装 (:meth:`aiohttp.ClientSession.ws_connect` の ``heartbeat`` 引数) によるものです。
 
 
 .. _manual-websocket-heartbeat:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_new_tab_link",
     "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -53,6 +54,12 @@ language = "ja"
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".venv"]
 
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
+    "aiohttp": ("https://docs.aiohttp.org/en/stable/", None),
+}
+intersphinx_disabled_domains = ["std"]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -30,7 +30,7 @@ Client class
 
 .. note::
 
-    pybotters の中核機能は `asyncio <https://docs.python.org/ja/3/library/asyncio.html>`_ と `aiohttp <https://docs.aiohttp.org/en/stable/client_quickstart.html>`__ の上に構築されています。
+    pybotters の中核機能は :mod:`asyncio` と :mod:`aiohttp` の上に構築されています。
     それらの知識が全くないと、このユーザーガイドを進めるのは難しいかもしれません。
 
     asyncio と aiohttp を掻い摘んで理解するには、著者によるこちらの記事がおすすめです。
@@ -77,7 +77,7 @@ Fetch API
 第 2 引数 (``url``) はリクエストの URL です。 文字列で指定します。
 
 返り値は :class:`.FetchResult` です。
-:attr:`.FetchResult.response` 属性には `aiohttp.ClientResponse <https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse>`_ が格納されており、
+:attr:`.FetchResult.response` 属性には :class:`aiohttp.ClientResponse` が格納されており、
 :attr:`.FetchResult.data` 属性にはデコードされた JSON データが格納されています。
 
 .. versionadded:: 1.0
@@ -90,7 +90,7 @@ HTTP method API
 従来の :ref:`HTTP メソッド API <http-method-api>` で HTTP リクエストを作成します。
 
 :ref:`HTTP メソッド API <http-method-api>` でリクエストを開始するには *async with* ブロックを利用します。
-こちらは従来の `aiohttp.ClientSession <https://docs.aiohttp.org/en/stable/client_reference.html#client-session>`_ と同様のリクエスト／レスポンスのフローになります。
+こちらは従来の :class:`aiohttp.ClientSession` と同様のリクエスト／レスポンスのフローになります。
 
 * :meth:`.Client.request`
 * :meth:`.Client.get`
@@ -117,7 +117,7 @@ HTTP method API
                 data = await resp.json()
             print(data)
 
-まず *async with* ブロックの返り値によってレスポンス `aiohttp.ClientResponse <https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse>`_ を受信します。
+まず *async with* ブロックの返り値によってレスポンス :class:`aiohttp.ClientResponse` を受信します。
 このレスポンスは HTTP ヘッダーまでとなります。
 そして *async* :meth:`json` メソッドを ``await`` するによって残りの HTTP 本文が受信され、データが JSON としてデコードされた値が返ります。
 
@@ -174,7 +174,7 @@ Response headers and data
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :ref:`Fetch API <fetch-api>` の戻り値におけるオブジェクト属性 :attr:`.FetchResult.response` と、
-:ref:`HTTP メソッド API <http-method-api>` の戻り値は共に `aiohttp.ClientResponse <https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse>`_ です。
+:ref:`HTTP メソッド API <http-method-api>` の戻り値は共に :class:`aiohttp.ClientResponse` です。
 
 HTTP レスポンスヘッダーについては、 ``headers`` 属性から取得できます。
 
@@ -709,9 +709,9 @@ aiohttp との違いについて。
 
 pybotters は `aiohttp <https://pypi.org/project/aiohttp/>`__ を基盤として利用しているライブラリです。
 
-その為、:class:`pybotters.Client` におけるインターフェースの多くは ``aiohttp.ClientSession`` と同様です。
-また pybotters の HTTP リクエストのレスポンスクラスは aiohttp のレスポンスクラスを返します。
-その為 pybotters を高度に利用するには aiohttp ライブラリについても理解しておくことが重要です。
+その為、:class:`pybotters.Client` におけるインターフェースの多くは :class:`aiohttp.ClientSession` と同様です。
+また pybotters の HTTP リクエストのレスポンスクラスは :class:`aiohttp.ClientResponse` を返します。
+その為 pybotters を高度に利用するには :class:`aiohttp` ライブラリについても理解しておくことが重要です。
 
 ただし **重要な幾つかの違いも存在します** 。
 

--- a/pybotters/client.py
+++ b/pybotters/client.py
@@ -46,7 +46,7 @@ class Client:
         Args:
             apis: API 認証情報
             base_url: ベース URL
-            **kwargs: aiohttp.ClientSession にバイパスされる引数
+            **kwargs: :class:`aiohttp.ClientSession` にバイパスされる引数
         """
         self._session = aiohttp.ClientSession(
             request_class=ClientRequest,
@@ -109,10 +109,10 @@ class Client:
             params: リクエスト URL のクエリ文字列
             data: リクエストの本文で送信するデータ
             auth: 認証オプション (デフォルトで有効、None で無効)
-            **kwargs: aiohttp.ClientSession.request にバイパスされる引数
+            **kwargs: :meth:`aiohttp.ClientSession.request` にバイパスされる引数
 
         Returns:
-            aiohttp.ClientResponse
+            :class:`aiohttp.ClientResponse`
 
         Usage example: :ref:`http-method-api`
         """
@@ -135,7 +135,7 @@ class Client:
             params: リクエスト URL のクエリ文字列
             data: リクエストの本文で送信するデータ
             auth: 認証オプション (デフォルトで有効、None で無効)
-            **kwargs: aiohttp.ClientSession.request にバイパスされる引数
+            **kwargs: :meth:`aiohttp.ClientSession.request` にバイパスされる引数
 
         Returns:
             FetchResult
@@ -166,10 +166,10 @@ class Client:
             url: リクエスト URL
             params: リクエスト URL のクエリ文字列
             auth: 認証オプション (デフォルトで有効、None で無効)
-            **kwargs: aiohttp.ClientSession.request にバイパスされる引数
+            **kwargs: :meth:`aiohttp.ClientSession.request` にバイパスされる引数
 
         Returns:
-            aiohttp.ClientResponse
+            :class:`aiohttp.ClientResponse`
 
         Usage example: :ref:`http-method-api`
         """
@@ -188,10 +188,10 @@ class Client:
             url: リクエスト URL
             data: リクエストの本文で送信するデータ
             auth: 認証オプション (デフォルトで有効、None で無効)
-            **kwargs: aiohttp.ClientSession.request にバイパスされる引数
+            **kwargs: :meth:`aiohttp.ClientSession.request` にバイパスされる引数
 
         Returns:
-            aiohttp.ClientResponse
+            :class:`aiohttp.ClientResponse`
 
         Usage example: :ref:`http-method-api`
         """
@@ -211,10 +211,10 @@ class Client:
             params: リクエスト URL のクエリ文字列
             data: リクエストの本文で送信するデータ
             auth: 認証オプション (デフォルトで有効、None で無効)
-            **kwargs: aiohttp.ClientSession.request にバイパスされる引数
+            **kwargs: :meth:`aiohttp.ClientSession.request` にバイパスされる引数
 
         Returns:
-            aiohttp.ClientResponse
+            :class:`aiohttp.ClientResponse`
 
         Usage example: :ref:`http-method-api`
         """
@@ -234,10 +234,10 @@ class Client:
             params: リクエスト URL のクエリ文字列
             data: リクエストの本文で送信するデータ
             auth: 認証オプション (デフォルトで有効、None で無効)
-            **kwargs: aiohttp.ClientSession.request にバイパスされる引数
+            **kwargs: :meth:`aiohttp.ClientSession.request` にバイパスされる引数
 
         Returns:
-            aiohttp.ClientResponse
+            :class:`aiohttp.ClientResponse`
 
         Usage example: :ref:`http-method-api`
         """
@@ -273,7 +273,7 @@ class Client:
             autoping: Ping に対する自動 Pong 応答 (デフォルト True)
             heartbeat: WebSocket ハートビート (デフォルト 10.0 秒)
             auth: 認証オプション (デフォルトで有効、None で無効)
-            **kwargs: aiohttp.ClientSession.ws_connect にバイパスされる引数
+            **kwargs: :meth:`aiohttp.ClientSession.ws_connect` にバイパスされる引数
 
         Returns:
             WebSocketApp
@@ -346,7 +346,7 @@ class FetchResult:
     """Fetch API result.
 
     Attributes:
-        response: `aiohttp.ClientResponse`
+        response: :class:`aiohttp.ClientResponse`
         text: テキストデータ
         data: JSON データ (JSON ではない場合は :class:`.NotJSONContent`)
     """


### PR DESCRIPTION
Now the pybotters docs should link nicely to the aiohttp docs, so you can jump straight to the right classes and methods!