### PR TITLE
Add an llms.txt for pybotters

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,6 +84,8 @@ templates_path = ["_templates"]
 
 html_title = "pybotters Docs"
 
+html_baseurl = "https://pybotters.readthedocs.io/ja/stable/"
+
 # -- Options llms.txt --------------------------------------------------------
 
 llms_txt_summary = """`pybotters` is a Python library for crypto bot traders.
@@ -93,8 +95,9 @@ It has the following features, making it useful for developing a trading bot.
 Please note: The links below are in HTML format due to the documentation builder's
 requirements. However, you can access the original source files (reStructuredText)
 directly.
-For example, for `/index.html`, you can access the source at `/_sources/index.rst.txt`.
-For LLMs, using the source files is generally more efficient than parsing HTML."""
+For example, for `https://pybotters.readthedocs.io/ja/stable/index.html`, you can access
+the source at `https://pybotters.readthedocs.io/ja/stable/_sources/index.rst.txt`. For
+LLMs, using the source files is generally more efficient than parsing HTML."""
 llms_txt_exclude = [
     "generated/*",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ extensions = [
     "sphinx_new_tab_link",
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
+    "sphinx_llms_txt",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -82,3 +83,18 @@ autoclass_content = "both"
 templates_path = ["_templates"]
 
 html_title = "pybotters Docs"
+
+# -- Options llms.txt --------------------------------------------------------
+
+llms_txt_summary = """`pybotters` is a Python library for crypto bot traders.
+This library is an **HTTP and WebSocket API client**.
+It has the following features, making it useful for developing a trading bot.
+
+Please note: The links below are in HTML format due to the documentation builder's
+requirements. However, you can access the original source files (reStructuredText)
+directly.
+For example, for `/index.html`, you can access the source at `/_sources/index.rst.txt`.
+For LLMs, using the source files is generally more efficient than parsing HTML."""
+llms_txt_exclude = [
+    "generated/*",
+]

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -3,3 +3,4 @@ sphinx==8.1.3
 sphinx-autobuild==2024.10.3
 sphinx-copybutton==0.5.2
 sphinx-new-tab-link==0.8.0
+sphinx-llms-txt==0.2.2


### PR DESCRIPTION
Experiment with https://github.com/jdillard/sphinx-llms-txt

After merging this pull request, you should be able to access `llms.txt` and `llms-full.txt` at:

- https://pybotters.readthedocs.io/ja/latest/llms.txt
- https://pybotters.readthedocs.io/ja/latest/llms-full.txt