### PR TITLE
Add reStructuredText extension for VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
     "recommendations": [
         "ms-python.python",
         "ms-python.mypy-type-checker",
-        "charliermarsh.ruff"
+        "charliermarsh.ruff",
+        "lextudio.restructuredtext"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,6 @@
         "tests"
     ],
     "python.testing.pytestEnabled": true,
-    "python.testing.unittestEnabled": false
+    "python.testing.unittestEnabled": false,
+    "restructuredtext.linter.run": "off"
 }

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,3 +4,7 @@
 -r test.txt
 -r lint.txt
 -r typing.txt
+
+# For VS Code extension "reStructuredText" (`lextudio.restructuredtext`)
+doc8==1.1.2
+rstcheck==6.2.5


### PR DESCRIPTION
Add VS Code Sphinx extension for documentation writing.

This PR adds a dependencies[^1] for the Sphinx VS Code extension to help with documentation authoring. Note: this is an IDE-only dependency, not a docs runtime requirement. Also, linter settings for reStructuredText are disabled for now—even though the dependencies are installed—because there are currently too many lint errors in the docs.

[^1]: https://docs.lextudio.com/restructuredtext/articles/prerequisites#install-doc8-or-rstcheck-as-linter