### PR TITLE
Increase open pull requests limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
   # Maintain dependencies for pip
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Increase Dependabot open pull requests limit from 5 to 10. This prevents important dependency PRs from being blocked due to the default